### PR TITLE
Divide database into schemas

### DIFF
--- a/src/SMAIAXBackend.API/Program.cs
+++ b/src/SMAIAXBackend.API/Program.cs
@@ -10,9 +10,9 @@ using SMAIAXBackend.Infrastructure.Repositories;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddDbContext<UserStoreDbContext>(options =>
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
 {
-    options.UseNpgsql(builder.Configuration.GetConnectionString("user-store"));
+    options.UseNpgsql(builder.Configuration.GetConnectionString("smaiax-db"));
 });
 
 builder.Services.AddIdentity<IdentityUser, IdentityRole>(options =>
@@ -25,7 +25,7 @@ builder.Services.AddIdentity<IdentityUser, IdentityRole>(options =>
         options.Password.RequiredLength = 8;
         options.Password.RequiredUniqueChars = 1;
     })
-    .AddEntityFrameworkStores<UserStoreDbContext>()
+    .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddDefaultTokenProviders();
 
 // Application Services.
@@ -52,7 +52,7 @@ if (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("DockerDeve
     app.UseSwagger();
     app.UseSwaggerUI();
 
-    var userStoreDbContext = services.GetRequiredService<UserStoreDbContext>();
+    var userStoreDbContext = services.GetRequiredService<ApplicationDbContext>();
     await userStoreDbContext.Database.EnsureDeletedAsync();
     await userStoreDbContext.Database.EnsureCreatedAsync();
 }

--- a/src/SMAIAXBackend.API/appsettings.Development.json
+++ b/src/SMAIAXBackend.API/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "user-store": "Host=localhost:5432;Username=user;Password=password;Database=user-store"
+    "smaiax-db": "Host=localhost:5432;Username=user;Password=password;Database=smaiax-db"
   },
   "JwtConfiguration": {
     "Secret": "YourNewStrongSecretKeyOfAtLeast32Characters!",

--- a/src/SMAIAXBackend.API/appsettings.DockerDevelopment.json
+++ b/src/SMAIAXBackend.API/appsettings.DockerDevelopment.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "user-store": "Host=smaiax-backend-db:5432;Username=user;Password=password;Database=user-store"
+    "smaiax-db": "Host=smaiax-backend-db:5432;Username=user;Password=password;Database=smaiax-db"
   },
   "JwtConfiguration": {
     "Secret": "YourNewStrongSecretKeyOfAtLeast32Characters!",

--- a/src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs
+++ b/src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs
@@ -25,6 +25,15 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         builder.ApplyConfiguration(new DomainUserConfiguration());
         builder.ApplyConfiguration(new RefreshTokenConfiguration());
 
+        // Place Identity tables in the "auth" schema
+        builder.Entity<IdentityUser>(entity => entity.ToTable(name: "AspNetUsers", schema: "auth"));
+        builder.Entity<IdentityRole>(entity => entity.ToTable(name: "AspNetRoles", schema: "auth"));
+        builder.Entity<IdentityUserRole<string>>(entity => entity.ToTable("AspNetUserRoles", schema: "auth"));
+        builder.Entity<IdentityUserClaim<string>>(entity => entity.ToTable("AspNetUserClaims", schema: "auth"));
+        builder.Entity<IdentityUserLogin<string>>(entity => entity.ToTable("AspNetUserLogins", schema: "auth"));
+        builder.Entity<IdentityRoleClaim<string>>(entity => entity.ToTable("AspNetRoleClaims", schema: "auth"));
+        builder.Entity<IdentityUserToken<string>>(entity => entity.ToTable("AspNetUserTokens", schema: "auth"));
+
         SeedTestData(builder);
     }
 

--- a/src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs
+++ b/src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs
@@ -7,7 +7,8 @@ using SMAIAXBackend.Infrastructure.EntityConfigurations;
 
 namespace SMAIAXBackend.Infrastructure.DbContexts;
 
-public class UserStoreDbContext(DbContextOptions<UserStoreDbContext> options) : IdentityDbContext<IdentityUser>(options)
+public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+    : IdentityDbContext<IdentityUser>(options)
 {
     public DbSet<User> DomainUsers { get; init; }
     public DbSet<RefreshToken> RefreshTokens { get; init; }

--- a/src/SMAIAXBackend.Infrastructure/EntityConfigurations/DomainUserConfiguration.cs
+++ b/src/SMAIAXBackend.Infrastructure/EntityConfigurations/DomainUserConfiguration.cs
@@ -9,21 +9,21 @@ public class DomainUserConfiguration : IEntityTypeConfiguration<User>
 {
     public void Configure(EntityTypeBuilder<User> builder)
     {
-        builder.ToTable("DomainUser");
-        
+        builder.ToTable("DomainUser", "domain");
+
         builder.HasKey(u => u.Id);
         builder.Property(u => u.Id)
             .HasConversion(
                 v => v.Id,
                 v => new UserId(v))
             .IsRequired();
-        
+
         builder.OwnsOne(u => u.Name, name =>
         {
             name.Property(fn => fn.FirstName).HasColumnName("firstName").IsRequired();
             name.Property(fn => fn.LastName).HasColumnName("lastName").IsRequired();
         });
-        
+
         builder.OwnsOne(u => u.Address, address =>
         {
             address.Property(a => a.Street).HasColumnName("street").IsRequired();
@@ -32,7 +32,7 @@ public class DomainUserConfiguration : IEntityTypeConfiguration<User>
             address.Property(a => a.ZipCode).HasColumnName("zipCode").IsRequired();
             address.Property(a => a.Country).HasColumnName("country").IsRequired();
         });
-        
+
         builder.Property(u => u.Email)
             .IsRequired();
     }

--- a/src/SMAIAXBackend.Infrastructure/EntityConfigurations/RefreshTokenConfiguration.cs
+++ b/src/SMAIAXBackend.Infrastructure/EntityConfigurations/RefreshTokenConfiguration.cs
@@ -9,7 +9,7 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
 {
     public void Configure(EntityTypeBuilder<RefreshToken> builder)
     {
-        builder.ToTable("RefreshToken");
+        builder.ToTable("RefreshToken", "auth");
 
         builder.HasKey(rt => rt.Id);
         builder.Property(rt => rt.Id)

--- a/src/SMAIAXBackend.Infrastructure/Repositories/TokenRepository.cs
+++ b/src/SMAIAXBackend.Infrastructure/Repositories/TokenRepository.cs
@@ -12,7 +12,7 @@ using SMAIAXBackend.Infrastructure.DbContexts;
 
 namespace SMAIAXBackend.Infrastructure.Repositories;
 
-public class TokenRepository(IOptions<JwtConfiguration> jwtConfigOptions, UserStoreDbContext userStoreDbContext)
+public class TokenRepository(IOptions<JwtConfiguration> jwtConfigOptions, ApplicationDbContext applicationDbContext)
     : ITokenRepository
 {
     private readonly JwtConfiguration _jwtConfig = jwtConfigOptions.Value;
@@ -59,15 +59,15 @@ public class TokenRepository(IOptions<JwtConfiguration> jwtConfigOptions, UserSt
         var refreshToken = RefreshToken.Create(refreshTokenId, new UserId(Guid.Parse(userId)), jwtTokenId,
             token, true, DateTime.UtcNow.AddMinutes(_jwtConfig.RefreshTokenExpirationMinutes));
 
-        await userStoreDbContext.RefreshTokens.AddAsync(refreshToken);
-        await userStoreDbContext.SaveChangesAsync();
+        await applicationDbContext.RefreshTokens.AddAsync(refreshToken);
+        await applicationDbContext.SaveChangesAsync();
 
         return refreshToken;
     }
 
     public async Task<RefreshToken?> GetRefreshTokenByTokenAsync(string token)
     {
-        return await userStoreDbContext.RefreshTokens
+        return await applicationDbContext.RefreshTokens
             .Where(rt => rt.Token.Equals(token))
             .SingleOrDefaultAsync();
     }
@@ -84,7 +84,7 @@ public class TokenRepository(IOptions<JwtConfiguration> jwtConfigOptions, UserSt
 
     public async Task UpdateAsync(RefreshToken refreshToken)
     {
-        userStoreDbContext.RefreshTokens.Update(refreshToken);
-        await userStoreDbContext.SaveChangesAsync();
+        applicationDbContext.RefreshTokens.Update(refreshToken);
+        await applicationDbContext.SaveChangesAsync();
     }
 }

--- a/src/SMAIAXBackend.Infrastructure/Repositories/UserRepository.cs
+++ b/src/SMAIAXBackend.Infrastructure/Repositories/UserRepository.cs
@@ -5,7 +5,7 @@ using SMAIAXBackend.Infrastructure.DbContexts;
 
 namespace SMAIAXBackend.Infrastructure.Repositories;
 
-public class UserRepository(UserStoreDbContext userStoreDbContext) : IUserRepository
+public class UserRepository(ApplicationDbContext applicationDbContext) : IUserRepository
 {
     public UserId NextIdentity()
     {
@@ -14,7 +14,7 @@ public class UserRepository(UserStoreDbContext userStoreDbContext) : IUserReposi
 
     public async Task AddAsync(User user)
     {
-        await userStoreDbContext.DomainUsers.AddAsync(user);
-        await userStoreDbContext.SaveChangesAsync();
+        await applicationDbContext.DomainUsers.AddAsync(user);
+        await applicationDbContext.SaveChangesAsync();
     }
 }

--- a/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/AuthenticationTests.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/AuthenticationTests.cs
@@ -31,9 +31,9 @@ public class AuthenticationTests : TestBase
         response.EnsureSuccessStatusCode();
         Assert.That(responseContent, Is.Not.Null);
 
-        var identityUser = await UserStoreDbContext.Users
+        var identityUser = await ApplicationDbContext.Users
             .SingleOrDefaultAsync(u => u.Id == id.ToString());
-        var domainUser = await UserStoreDbContext.DomainUsers
+        var domainUser = await ApplicationDbContext.DomainUsers
             .SingleOrDefaultAsync(u => u.Id == new UserId(id));
 
         Assert.Multiple(() =>

--- a/tests/SMAIAXBackend.IntegrationTests/IntegrationTestSetup.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/IntegrationTestSetup.cs
@@ -4,15 +4,14 @@ using Testcontainers.PostgreSql;
 
 namespace SMAIAXBackend.IntegrationTests;
 
-
 [SetUpFixture]
 internal static class IntegrationTestSetup
 {
     private static PostgreSqlContainer _postgresContainer = null!;
     private static WebAppFactory _webAppFactory = null!;
-    public static UserStoreDbContext UserStoreDbContext { get; private set; } = null!;
+    public static ApplicationDbContext ApplicationDbContext { get; private set; } = null!;
     public static HttpClient HttpClient { get; private set; } = null!;
-    
+
     [OneTimeSetUp]
     public static async Task OneTimeSetup()
     {
@@ -20,17 +19,18 @@ internal static class IntegrationTestSetup
             .WithImage("postgres:16-bullseye")
             .WithUsername("user")
             .WithPassword("password")
-            .WithDatabase("user-store")
+            .WithDatabase("smaiax-db")
             .WithPortBinding(5432, true)
             .Build();
 
         await _postgresContainer.StartAsync();
 
-        _webAppFactory = new WebAppFactory(_postgresContainer.GetConnectionString());
+        var connectionString = _postgresContainer.GetConnectionString();
+        _webAppFactory = new WebAppFactory(connectionString);
 
         HttpClient = _webAppFactory.CreateClient();
 
-        UserStoreDbContext = _webAppFactory.Services.GetRequiredService<UserStoreDbContext>();
+        ApplicationDbContext = _webAppFactory.Services.GetRequiredService<ApplicationDbContext>();
     }
 
     [OneTimeTearDown]

--- a/tests/SMAIAXBackend.IntegrationTests/TestBase.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/TestBase.cs
@@ -7,20 +7,20 @@ namespace SMAIAXBackend.IntegrationTests;
 public class TestBase
 {
     protected readonly HttpClient HttpClient = IntegrationTestSetup.HttpClient;
-    protected readonly UserStoreDbContext UserStoreDbContext = IntegrationTestSetup.UserStoreDbContext;
+    protected readonly ApplicationDbContext ApplicationDbContext = IntegrationTestSetup.ApplicationDbContext;
 
     [SetUp]
     public async Task Setup()
     {
-        await IntegrationTestSetup.UserStoreDbContext.Database.EnsureCreatedAsync();
+        await IntegrationTestSetup.ApplicationDbContext.Database.EnsureCreatedAsync();
         await InsertTestData();
-        IntegrationTestSetup.UserStoreDbContext.ChangeTracker.Clear();
+        IntegrationTestSetup.ApplicationDbContext.ChangeTracker.Clear();
     }
 
     [TearDown]
     public async Task TearDown()
     {
-        await IntegrationTestSetup.UserStoreDbContext.Database.EnsureDeletedAsync();
+        await IntegrationTestSetup.ApplicationDbContext.Database.EnsureDeletedAsync();
     }
 
     private async Task InsertTestData()
@@ -75,10 +75,10 @@ public class TestBase
             expirationDate1
         );
 
-        await UserStoreDbContext.RefreshTokens.AddAsync(refreshToken1);
-        await UserStoreDbContext.RefreshTokens.AddAsync(refreshToken2);
-        await UserStoreDbContext.RefreshTokens.AddAsync(refreshToken3);
-        await UserStoreDbContext.RefreshTokens.AddAsync(refreshToken4);
-        await UserStoreDbContext.SaveChangesAsync();
+        await ApplicationDbContext.RefreshTokens.AddAsync(refreshToken1);
+        await ApplicationDbContext.RefreshTokens.AddAsync(refreshToken2);
+        await ApplicationDbContext.RefreshTokens.AddAsync(refreshToken3);
+        await ApplicationDbContext.RefreshTokens.AddAsync(refreshToken4);
+        await ApplicationDbContext.SaveChangesAsync();
     }
 }

--- a/tests/SMAIAXBackend.IntegrationTests/WebAppFactory.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/WebAppFactory.cs
@@ -8,13 +8,13 @@ public class WebAppFactory(string postgresConnectionString) : WebApplicationFact
 {
     private readonly Dictionary<string, string> _testAppSettings = new()
     {
-        ["ConnectionStrings:user-store"] = postgresConnectionString,
+        ["ConnectionStrings:smaiax-db"] = postgresConnectionString,
         ["JwtConfiguration:Secret"] = "YourNewStrongSecretKeyOfAtLeast32Characters!",
         ["JwtConfiguration:Issuer"] = "SMAIAX",
         ["JwtConfiguration:Audience"] = "SomeAudience",
         ["JwtConfiguration:ExpirationMinutes"] = "60"
     };
-    
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         ConfigureAppSettings(builder);


### PR DESCRIPTION
- **refactor(db): rename UserStoreDbContext to ApplicationDbContext and update connection string**
  - Renamed `UserStoreDbContext` to `ApplicationDbContext` for better clarity.
  - Updated the connection string name from `user-store` to `smaiax-db`.
  - Changed the database name in the connection string from `user-store` to `smaiax-db`.
  

- **chore(db): configure PostgreSQL schemas for DomainUser and Identity tables**
  - Moved `DomainUser` to the `domain` schema in PostgreSQL.
  - Moved `RefreshToken` table to the `auth` schema in PostgreSQL.
  - Configured Identity Framework tables to be placed in the `auth` schema in PostgreSQL.
  