### PR TITLE
Define server url for open-api spec in backend

### DIFF
--- a/src/SMAIAXBackend.API/Program.cs
+++ b/src/SMAIAXBackend.API/Program.cs
@@ -62,11 +62,7 @@ if (builder.Environment.IsDevelopment() || builder.Environment.IsEnvironment("Do
         builder.Services.AddSwaggerGen(options =>
         {
             options.SwaggerDoc("v1", new OpenApiInfo { Title = "SMAIAX Backend API", Version = "v1" });
-            options.AddServer(new OpenApiServer
-            {
-                Url = httpProfileUrl.Trim(),
-                Description = "Development server"
-            });
+            options.AddServer(new OpenApiServer { Url = httpProfileUrl.Trim(), Description = "Development server" });
         });
     }
     else

--- a/src/SMAIAXBackend.API/Program.cs
+++ b/src/SMAIAXBackend.API/Program.cs
@@ -55,20 +55,16 @@ builder.Services.AddHostedService<MessagingBackgroundService>();
 if (builder.Environment.IsDevelopment() || builder.Environment.IsEnvironment("DockerDevelopment"))
 {
     builder.Configuration.AddJsonFile("Properties/launchSettings.json", optional: true, reloadOnChange: true);
-    var httpProfileUrl = builder.Configuration["profiles:http:applicationUrl"];
+    builder.Services.AddSwaggerGen(options =>
+    {
+        options.SwaggerDoc("v1", new OpenApiInfo { Title = "SMAIAX Backend API", Version = "v1" });
 
-    if (!string.IsNullOrEmpty(httpProfileUrl))
-    {
-        builder.Services.AddSwaggerGen(options =>
+        var httpProfileUrl = builder.Configuration["profiles:http:applicationUrl"];
+        if (!string.IsNullOrEmpty(httpProfileUrl))
         {
-            options.SwaggerDoc("v1", new OpenApiInfo { Title = "SMAIAX Backend API", Version = "v1" });
             options.AddServer(new OpenApiServer { Url = httpProfileUrl.Trim(), Description = "Development server" });
-        });
-    }
-    else
-    {
-        builder.Services.AddSwaggerGen();
-    }
+        }
+    });
 }
 
 var app = builder.Build();

--- a/src/SMAIAXBackend.API/Program.cs
+++ b/src/SMAIAXBackend.API/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
 
 using SMAIAXBackend.API;
 using SMAIAXBackend.Application.Interfaces;
@@ -45,12 +46,35 @@ builder.Services.Configure<JwtConfiguration>(builder.Configuration.GetSection("J
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();
 builder.Services.Configure<MqttSettings>(builder.Configuration.GetSection("MQTT"));
 builder.Services.AddSingleton<IMqttReader, MqttReader>();
 builder.Services.AddHostedService<MessagingBackgroundService>();
+
+if (builder.Environment.IsDevelopment() || builder.Environment.IsEnvironment("DockerDevelopment"))
+{
+    builder.Configuration.AddJsonFile("Properties/launchSettings.json", optional: true, reloadOnChange: true);
+    var httpProfileUrl = builder.Configuration["profiles:http:applicationUrl"];
+
+    if (!string.IsNullOrEmpty(httpProfileUrl))
+    {
+        builder.Services.AddSwaggerGen(options =>
+        {
+            options.SwaggerDoc("v1", new OpenApiInfo { Title = "SMAIAX Backend API", Version = "v1" });
+            options.AddServer(new OpenApiServer
+            {
+                Url = httpProfileUrl.Trim(),
+                Description = "Development server"
+            });
+        });
+    }
+    else
+    {
+        builder.Services.AddSwaggerGen();
+    }
+}
+
 var app = builder.Build();
 using var scope = app.Services.CreateScope();
 var services = scope.ServiceProvider;


### PR DESCRIPTION
feat(openapi): load launchSettings.json and configure Swagger with http profile URL in development

- Added logic to load `launchSettings.json` in development or DockerDevelopment environments.
- Configured Swagger to use the `http` profile's `applicationUrl` for the development server.