### PR TITLE
Add metadata to smart meter

### DIFF
--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/AddMetadataEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/AddMetadataEndpoint.cs
@@ -1,0 +1,23 @@
+using System.Security.Claims;
+
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+using SMAIAXBackend.Application.DTOs;
+using SMAIAXBackend.Application.Services.Interfaces;
+
+namespace SMAIAXBackend.API.Endpoints.SmartMeter;
+
+public static class AddMetadataEndpoint
+{
+    public static async Task<Results<Ok<Guid>, ProblemHttpResult>> Handle(
+        ISmartMeterCreateService smartMeterCreateService,
+        [FromRoute] Guid id,
+        [FromBody] MetadataCreateDto metadataCreateDto,
+        ClaimsPrincipal user)
+    {
+        var userIdClaim = user.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
+        var smartMeterId = await smartMeterCreateService.AddMetadataAsync(id, metadataCreateDto, userIdClaim);
+        return TypedResults.Ok(smartMeterId);
+    }
+}

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/SmartMeterEndpoints.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/SmartMeterEndpoints.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+
 using SMAIAXBackend.Application.DTOs;
 
 namespace SMAIAXBackend.API.Endpoints.SmartMeter;
@@ -31,6 +33,16 @@ public static class SmartMeterEndpoints
             .Produces<Guid>(StatusCodes.Status201Created, contentType)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
+        
+        group.MapPost("/{id:guid}/metadata", AddMetadataEndpoint.Handle)
+            .WithName("addMetadata")
+            .Accepts<MetadataCreateDto>(contentType)
+            .Produces<Ok>(StatusCodes.Status200OK, contentType)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesProblem(StatusCodes.Status500InternalServerError);
 
         return app;

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/SmartMeterEndpoints.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/SmartMeterEndpoints.cs
@@ -34,7 +34,7 @@ public static class SmartMeterEndpoints
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status500InternalServerError);
-        
+
         group.MapPost("/{id:guid}/metadata", AddMetadataEndpoint.Handle)
             .WithName("addMetadata")
             .Accepts<MetadataCreateDto>(contentType)

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/SmartMeterEndpoints.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/SmartMeterEndpoints.cs
@@ -41,7 +41,7 @@ public static class SmartMeterEndpoints
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status500InternalServerError);
-        
+
         group.MapPost("/{id:guid}/metadata", AddMetadataEndpoint.Handle)
             .WithName("addMetadata")
             .Accepts<MetadataCreateDto>(contentType)

--- a/src/SMAIAXBackend.API/GlobalExceptionHandler.cs
+++ b/src/SMAIAXBackend.API/GlobalExceptionHandler.cs
@@ -34,6 +34,11 @@ public class GlobalExceptionHandler : IExceptionHandler
                 problemDetails.Status = StatusCodes.Status400BadRequest;
                 problemDetails.Title = "Registration Error";
                 break;
+            case ArgumentException:
+                problemDetails.Type = "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.8";
+                problemDetails.Status = StatusCodes.Status409Conflict;
+                problemDetails.Title = "Conflict";
+                break;
             default:
                 problemDetails.Type = "https://datatracker.ietf.org/doc/html/rfc9110#section-15.6.1";
                 problemDetails.Status = StatusCodes.Status500InternalServerError;

--- a/src/SMAIAXBackend.Application/DTOs/LocationDto.cs
+++ b/src/SMAIAXBackend.Application/DTOs/LocationDto.cs
@@ -1,0 +1,12 @@
+using SMAIAXBackend.Domain.Model.Enums;
+
+namespace SMAIAXBackend.Application.DTOs;
+
+public class LocationDto(string? streetName, string? city, string? state, string? country, Continent? continent)
+{
+    public string? StreetName { get; set;  } = streetName;
+    public string? City { get; set;  } = city;
+    public string? State { get; set;  } = state;
+    public string? Country { get; set; } = country;
+    public Continent? Continent { get; set;  } = continent;
+}

--- a/src/SMAIAXBackend.Application/DTOs/LocationDto.cs
+++ b/src/SMAIAXBackend.Application/DTOs/LocationDto.cs
@@ -4,9 +4,9 @@ namespace SMAIAXBackend.Application.DTOs;
 
 public class LocationDto(string? streetName, string? city, string? state, string? country, Continent? continent)
 {
-    public string? StreetName { get; set;  } = streetName;
-    public string? City { get; set;  } = city;
-    public string? State { get; set;  } = state;
+    public string? StreetName { get; set; } = streetName;
+    public string? City { get; set; } = city;
+    public string? State { get; set; } = state;
     public string? Country { get; set; } = country;
-    public Continent? Continent { get; set;  } = continent;
+    public Continent? Continent { get; set; } = continent;
 }

--- a/src/SMAIAXBackend.Application/DTOs/MetadataCreateDto.cs
+++ b/src/SMAIAXBackend.Application/DTOs/MetadataCreateDto.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SMAIAXBackend.Application.DTOs;
+
+public class MetadataCreateDto(DateTime validFrom, LocationDto location, int householdSize)
+{
+    [Required]
+    public DateTime ValidFrom { get; set; } = validFrom;
+
+    [Required]
+    public LocationDto Location { get; set; } = location;
+    
+    [Required]
+    public int HouseholdSize { get; set; } = householdSize;
+}

--- a/src/SMAIAXBackend.Application/DTOs/MetadataCreateDto.cs
+++ b/src/SMAIAXBackend.Application/DTOs/MetadataCreateDto.cs
@@ -9,7 +9,7 @@ public class MetadataCreateDto(DateTime validFrom, LocationDto location, int hou
 
     [Required]
     public LocationDto Location { get; set; } = location;
-    
+
     [Required]
     public int HouseholdSize { get; set; } = householdSize;
 }

--- a/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterCreateService.cs
+++ b/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterCreateService.cs
@@ -43,7 +43,7 @@ public class SmartMeterCreateService(
             metadataCreateDto.Location.State, metadataCreateDto.Location.Country, metadataCreateDto.Location.Continent);
         var metadata = Metadata.Create(metadataId, metadataCreateDto.ValidFrom, location, metadataCreateDto.HouseholdSize, smartMeter.Id);
         smartMeter.AddMetadata(metadata);
-        
+
         await smartMeterRepository.UpdateAsync(smartMeter);
 
         return smartMeterId;

--- a/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterCreateService.cs
+++ b/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterCreateService.cs
@@ -1,13 +1,19 @@
+using Microsoft.Extensions.Logging;
+
 using SMAIAXBackend.Application.DTOs;
+using SMAIAXBackend.Application.Exceptions;
 using SMAIAXBackend.Application.Services.Interfaces;
 using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.ValueObjects;
+using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 using SMAIAXBackend.Domain.Repositories;
 
 namespace SMAIAXBackend.Application.Services.Implementations;
 
 public class SmartMeterCreateService(
     ISmartMeterRepository smartMeterRepository,
-    IUserValidationService userValidationService) : ISmartMeterCreateService
+    IUserValidationService userValidationService,
+    ILogger<SmartMeterCreateService> logger) : ISmartMeterCreateService
 {
     public async Task<Guid> AddSmartMeterAsync(SmartMeterCreateDto smartMeterCreateDto, string? userId)
     {
@@ -17,5 +23,29 @@ public class SmartMeterCreateService(
         await smartMeterRepository.AddAsync(smartMeter);
 
         return smartMeterId.Id;
+    }
+
+    public async Task<Guid> AddMetadataAsync(Guid smartMeterId, MetadataCreateDto metadataCreateDto, string? userId)
+    {
+        var validatedUserId = await userValidationService.ValidateUserAsync(userId);
+        var smartMeter =
+            await smartMeterRepository.GetSmartMeterByIdAndUserIdAsync(new SmartMeterId(smartMeterId), validatedUserId);
+
+        if (smartMeter == null)
+        {
+            logger.LogWarning("SmartMeter with id {SmartMeterId} not found for user {UserId}", smartMeterId,
+                validatedUserId.Id);
+            throw new SmartMeterNotFoundException(smartMeterId, validatedUserId.Id);
+        }
+
+        var metadataId = smartMeterRepository.NextMetadataIdentity();
+        var location = new Location(metadataCreateDto.Location.StreetName, metadataCreateDto.Location.City,
+            metadataCreateDto.Location.State, metadataCreateDto.Location.Country, metadataCreateDto.Location.Continent);
+        var metadata = Metadata.Create(metadataId, metadataCreateDto.ValidFrom, location, metadataCreateDto.HouseholdSize, smartMeter.Id);
+        smartMeter.AddMetadata(metadata);
+        
+        await smartMeterRepository.UpdateAsync(smartMeter);
+
+        return smartMeterId;
     }
 }

--- a/src/SMAIAXBackend.Application/Services/Interfaces/ISmartMeterCreateService.cs
+++ b/src/SMAIAXBackend.Application/Services/Interfaces/ISmartMeterCreateService.cs
@@ -5,4 +5,5 @@ namespace SMAIAXBackend.Application.Services.Interfaces;
 public interface ISmartMeterCreateService
 {
     Task<Guid> AddSmartMeterAsync(SmartMeterCreateDto smartMeterCreateDto, string? userId);
+    Task<Guid> AddMetadataAsync(Guid smartMeterId, MetadataCreateDto metadataCreateDto, string? userId);
 }

--- a/src/SMAIAXBackend.Domain/Model/Entities/SmartMeter.cs
+++ b/src/SMAIAXBackend.Domain/Model/Entities/SmartMeter.cs
@@ -41,10 +41,10 @@ public sealed class SmartMeter : IEquatable<SmartMeter>
         {
             throw new ArgumentException("Metadata already exists");
         }
-        
+
         Metadata.Add(metadata);
     }
-    
+
     [ExcludeFromCodeCoverage]
     public bool Equals(SmartMeter? other)
     {

--- a/src/SMAIAXBackend.Domain/Model/Entities/SmartMeter.cs
+++ b/src/SMAIAXBackend.Domain/Model/Entities/SmartMeter.cs
@@ -35,6 +35,16 @@ public sealed class SmartMeter : IEquatable<SmartMeter>
         Policies = policies;
     }
 
+    public void AddMetadata(Metadata metadata)
+    {
+        if (Metadata.Contains(metadata))
+        {
+            throw new ArgumentException("Metadata already exists");
+        }
+        
+        Metadata.Add(metadata);
+    }
+    
     [ExcludeFromCodeCoverage]
     public bool Equals(SmartMeter? other)
     {

--- a/src/SMAIAXBackend.Domain/Repositories/ISmartMeterRepository.cs
+++ b/src/SMAIAXBackend.Domain/Repositories/ISmartMeterRepository.cs
@@ -6,7 +6,9 @@ namespace SMAIAXBackend.Domain.Repositories;
 public interface ISmartMeterRepository
 {
     SmartMeterId NextIdentity();
+    MetadataId NextMetadataIdentity();
     Task AddAsync(SmartMeter meter);
     Task<List<SmartMeter>> GetSmartMetersByUserIdAsync(UserId userId);
     Task<SmartMeter?> GetSmartMeterByIdAndUserIdAsync(SmartMeterId smartMeterId, UserId userId);
+    Task UpdateAsync(SmartMeter smartMeter);
 }

--- a/src/SMAIAXBackend.Infrastructure/EntityConfigurations/MetadataConfiguration.cs
+++ b/src/SMAIAXBackend.Infrastructure/EntityConfigurations/MetadataConfiguration.cs
@@ -21,6 +21,8 @@ public class MetadataConfiguration : IEntityTypeConfiguration<Metadata>
 
         builder.Property(m => m.ValidFrom)
             .IsRequired();
+        builder.HasIndex(m => m.ValidFrom)
+            .IsUnique();
 
         builder.OwnsOne(m => m.Location, location =>
         {

--- a/src/SMAIAXBackend.Infrastructure/Repositories/SmartMeterRepository.cs
+++ b/src/SMAIAXBackend.Infrastructure/Repositories/SmartMeterRepository.cs
@@ -14,6 +14,11 @@ public class SmartMeterRepository(ApplicationDbContext applicationDbContext) : I
         return new SmartMeterId(Guid.NewGuid());
     }
 
+    public MetadataId NextMetadataIdentity()
+    {
+        return new MetadataId(Guid.NewGuid());
+    }
+
     public async Task AddAsync(SmartMeter meter)
     {
         await applicationDbContext.SmartMeters.AddAsync(meter);
@@ -35,5 +40,11 @@ public class SmartMeterRepository(ApplicationDbContext applicationDbContext) : I
             .Include(sm => sm.Metadata)
             .Include(sm => sm.Policies)
             .FirstOrDefaultAsync(sm => sm.Id.Equals(smartMeterId) && sm.UserId.Equals(userId));
+    }
+
+    public async Task UpdateAsync(SmartMeter smartMeter)
+    {
+        applicationDbContext.SmartMeters.Update(smartMeter);
+        await applicationDbContext.SaveChangesAsync();
     }
 }

--- a/tests/SMAIAXBackend.Application.UnitTests/SmartMeterCreateServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/SmartMeterCreateServiceTests.cs
@@ -1,9 +1,13 @@
+using Microsoft.Extensions.Logging;
+
 using Moq;
 
 using SMAIAXBackend.Application.DTOs;
+using SMAIAXBackend.Application.Exceptions;
 using SMAIAXBackend.Application.Services.Implementations;
 using SMAIAXBackend.Application.Services.Interfaces;
 using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.Enums;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 using SMAIAXBackend.Domain.Repositories;
 
@@ -14,6 +18,7 @@ public class SmartMeterCreateServiceTests
 {
     private Mock<ISmartMeterRepository> _smartMeterRepositoryMock;
     private Mock<IUserValidationService> _userValidationServiceMock;
+    private Mock<ILogger<SmartMeterCreateService>> _loggerMock;
     private SmartMeterCreateService _smartMeterCreateService;
 
     [SetUp]
@@ -21,8 +26,9 @@ public class SmartMeterCreateServiceTests
     {
         _smartMeterRepositoryMock = new Mock<ISmartMeterRepository>();
         _userValidationServiceMock = new Mock<IUserValidationService>();
+        _loggerMock = new Mock<ILogger<SmartMeterCreateService>>();
         _smartMeterCreateService = new SmartMeterCreateService(_smartMeterRepositoryMock.Object,
-            _userValidationServiceMock.Object);
+            _userValidationServiceMock.Object, _loggerMock.Object);
     }
 
     [Test]
@@ -33,14 +39,63 @@ public class SmartMeterCreateServiceTests
         var smartMeterCreateDto = new SmartMeterCreateDto("Test Smart Meter");
         var userId = new UserId(Guid.NewGuid());
 
-        _userValidationServiceMock.Setup(service => service.ValidateUserAsync(userId.Id.ToString())).ReturnsAsync(userId);
+        _userValidationServiceMock.Setup(service => service.ValidateUserAsync(userId.Id.ToString()))
+            .ReturnsAsync(userId);
         _smartMeterRepositoryMock.Setup(repo => repo.NextIdentity()).Returns(smartMeterIdExpected);
 
         // When
-        var smartMeterIdActual = await _smartMeterCreateService.AddSmartMeterAsync(smartMeterCreateDto, userId.Id.ToString());
+        var smartMeterIdActual =
+            await _smartMeterCreateService.AddSmartMeterAsync(smartMeterCreateDto, userId.Id.ToString());
 
         // Then
         Assert.That(smartMeterIdActual, Is.EqualTo(smartMeterIdExpected.Id));
         _smartMeterRepositoryMock.Verify(repo => repo.AddAsync(It.IsAny<SmartMeter>()), Times.Once);
+    }
+
+    [Test]
+    public async Task
+        GivenSmartMeterIdAndMetadataCreateDtoAndExistentUserId_WhenAddMetadata_ThenSmartMeterIdIsReturned()
+    {
+        // Given
+        var smartMeterId = new SmartMeterId(Guid.NewGuid());
+        var metadataIdExpected = new MetadataId(Guid.NewGuid());
+        var metadataCreateDto = new MetadataCreateDto(DateTime.Now,
+            new LocationDto("Test Street", "Test City", "Test State", "Test Country", Continent.Europe), 1);
+        var userId = new UserId(Guid.NewGuid());
+        var smartMeter = SmartMeter.Create(smartMeterId, "Test Smart Meter", userId);
+
+        _userValidationServiceMock.Setup(service => service.ValidateUserAsync(userId.Id.ToString()))
+            .ReturnsAsync(userId);
+        _smartMeterRepositoryMock.Setup(repo => repo.GetSmartMeterByIdAndUserIdAsync(smartMeterId, userId))
+            .ReturnsAsync(smartMeter);
+        _smartMeterRepositoryMock.Setup(repo => repo.NextMetadataIdentity()).Returns(metadataIdExpected);
+
+        // When
+        var smartMeterIdActual =
+            await _smartMeterCreateService.AddMetadataAsync(smartMeterId.Id, metadataCreateDto, userId.Id.ToString());
+
+        // Then
+        Assert.That(smartMeterIdActual, Is.EqualTo(smartMeterId.Id));
+        _smartMeterRepositoryMock.Verify(repo => repo.UpdateAsync(smartMeter), Times.Once);
+    }
+
+    [Test]
+    public void
+        GivenSmartMeterIdAndMetadataCreateDtoAndNonexistentUserId_WhenAddMetadata_ThenSmartMeterNotFoundExceptionIsThrown()
+    {
+        // Given
+        var smartMeterId = new SmartMeterId(Guid.NewGuid());
+        var metadataCreateDto = new MetadataCreateDto(DateTime.Now,
+            new LocationDto("Test Street", "Test City", "Test State", "Test Country", Continent.Europe), 1);
+        var userId = new UserId(Guid.NewGuid());
+
+        _userValidationServiceMock.Setup(service => service.ValidateUserAsync(userId.Id.ToString()))
+            .ReturnsAsync(userId);
+        _smartMeterRepositoryMock.Setup(repo => repo.GetSmartMeterByIdAndUserIdAsync(smartMeterId, userId))
+            .ReturnsAsync((SmartMeter)null!);
+
+        // Then ... Then
+        Assert.ThrowsAsync<SmartMeterNotFoundException>(async () =>
+            await _smartMeterCreateService.AddMetadataAsync(smartMeterId.Id, metadataCreateDto, userId.Id.ToString()));
     }
 }

--- a/tests/SMAIAXBackend.Domain.UnitTests/SmartMeterTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/SmartMeterTests.cs
@@ -1,4 +1,6 @@
 using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.Enums;
+using SMAIAXBackend.Domain.Model.ValueObjects;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 
 namespace SMAIAXBackend.Domain.UnitTests;
@@ -26,5 +28,36 @@ public class SmartMeterTests
             Assert.That(smartMeter.UserId, Is.EqualTo(userId));
             Assert.That(smartMeter.Policies, Is.Empty);
         });
+    }
+
+    [Test]
+    public void GivenSmartMeterAndMetadata_WhenAddMetadata_ThenMetadataIsAdded()
+    {
+        // Given
+        var smartMeter = SmartMeter.Create(new SmartMeterId(Guid.NewGuid()), "SmartMeter", new UserId(Guid.NewGuid()));
+        var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
+            new Location("Some street", "Some city", "Some state", "Some country", Continent.Europe), 
+            4, smartMeter.Id);
+
+        // When
+        smartMeter.AddMetadata(metadata);
+
+        // Then
+        Assert.That(smartMeter.Metadata, Has.Count.EqualTo(1));
+        Assert.That(smartMeter.Metadata[0], Is.EqualTo(metadata));
+    }
+
+    [Test]
+    public void GivenSmartMeterAndMetadata_WhenAddMetadataTwice_ThenArgumentExceptionIsThrown()
+    {
+        // Given
+        var smartMeter = SmartMeter.Create(new SmartMeterId(Guid.NewGuid()), "SmartMeter", new UserId(Guid.NewGuid()));
+        var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
+            new Location("Some street", "Some city", "Some state", "Some country", Continent.Europe), 
+            4, smartMeter.Id);
+        
+        // When ... Then
+        smartMeter.AddMetadata(metadata);
+        Assert.Throws<ArgumentException>(() => smartMeter.AddMetadata(metadata));
     }
 }

--- a/tests/SMAIAXBackend.Domain.UnitTests/SmartMeterTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/SmartMeterTests.cs
@@ -36,7 +36,7 @@ public class SmartMeterTests
         // Given
         var smartMeter = SmartMeter.Create(new SmartMeterId(Guid.NewGuid()), "SmartMeter", new UserId(Guid.NewGuid()));
         var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
-            new Location("Some street", "Some city", "Some state", "Some country", Continent.Europe), 
+            new Location("Some street", "Some city", "Some state", "Some country", Continent.Europe),
             4, smartMeter.Id);
 
         // When
@@ -53,9 +53,9 @@ public class SmartMeterTests
         // Given
         var smartMeter = SmartMeter.Create(new SmartMeterId(Guid.NewGuid()), "SmartMeter", new UserId(Guid.NewGuid()));
         var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
-            new Location("Some street", "Some city", "Some state", "Some country", Continent.Europe), 
+            new Location("Some street", "Some city", "Some state", "Some country", Continent.Europe),
             4, smartMeter.Id);
-        
+
         // When ... Then
         smartMeter.AddMetadata(metadata);
         Assert.Throws<ArgumentException>(() => smartMeter.AddMetadata(metadata));

--- a/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/SmartMeterTests.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/SmartMeterTests.cs
@@ -162,13 +162,13 @@ public class SmartMeterTests : TestBase
 
         // When
         var response = await _httpClient.PostAsync($"{BaseUrl}/{smartMeterId}/metadata", httpContent);
-        
+
         // Then
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-        
+
         var responseContent = await response.Content.ReadAsStringAsync();
         Assert.That(responseContent, Is.Not.Null);
-        
+
         var returnedId = Guid.Parse(responseContent.Trim('"'));
         Assert.That(returnedId, Is.EqualTo(smartMeterId));
 
@@ -176,7 +176,7 @@ public class SmartMeterTests : TestBase
             .AsNoTracking()
             .Include(smartMeter => smartMeter.Metadata)
             .FirstOrDefaultAsync(x => x.Id.Equals(new SmartMeterId(returnedId)));
-        
+
         Assert.That(smartMeter, Is.Not.Null);
         Assert.That(smartMeter.Metadata, Has.Count.EqualTo(metadataCountExpected));
         var metadataActual = smartMeter.Metadata[0];
@@ -191,7 +191,7 @@ public class SmartMeterTests : TestBase
             Assert.That(metadataActual.HouseholdSize, Is.EqualTo(metadataCreateDto.HouseholdSize));
         });
     }
-    
+
     [Test]
     public async Task GivenSmartMeterIdAndMetadataCreateDtoAndNoAccessToken_WhenAddMetadata_ThenUnauthorizedIsReturned()
     {


### PR DESCRIPTION
- Implemented POST endpoint for adding Metadata to a Smart Meter.
- Added AddMetadataAsync to SmartMeterCreateService
- Added UpdateAsync method in SmartMeterRepository.
- Created MetadataCreateDto and LocationDto.
- Implemented AddMetadata in SmartMeter.
- Added unit and integration tests for the new functionality.
