### PR TITLE
Remove metadata from smart meter

### DIFF
--- a/src/SMAIAXBackend.API/ApplicationConfigurations/ServiceExtensions.cs
+++ b/src/SMAIAXBackend.API/ApplicationConfigurations/ServiceExtensions.cs
@@ -14,6 +14,7 @@ public static class ServiceExtensions
         services.AddScoped<ISmartMeterCreateService, SmartMeterCreateService>();
         services.AddScoped<ISmartMeterListService, SmartMeterListService>();
         services.AddScoped<ISmartMeterUpdateService, SmartMeterUpdateService>();
+        services.AddScoped<ISmartMeterDeleteService, SmartMeterDeleteService>();
         services.AddScoped<IUserValidationService, UserValidationService>();
     }
 }

--- a/src/SMAIAXBackend.API/Endpoints/Authentication/AuthenticationEndpoints.cs
+++ b/src/SMAIAXBackend.API/Endpoints/Authentication/AuthenticationEndpoints.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http.HttpResults;
-
 using SMAIAXBackend.Application.DTOs;
 
 namespace SMAIAXBackend.API.Endpoints.Authentication;
@@ -38,7 +36,7 @@ public static class AuthenticationEndpoints
         group.MapPost("logout", LogoutEndpoint.Handle)
             .WithName("logout")
             .Accepts<TokenDto>(contentType)
-            .Produces<Ok>(StatusCodes.Status200OK, contentType)
+            .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status500InternalServerError);
 

--- a/src/SMAIAXBackend.API/Endpoints/Authentication/LoginEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/Authentication/LoginEndpoint.cs
@@ -8,7 +8,7 @@ namespace SMAIAXBackend.API.Endpoints.Authentication;
 
 public static class LoginEndpoint
 {
-    public static async Task<Results<Ok<TokenDto>, ProblemHttpResult>> Handle(
+    public static async Task<Ok<TokenDto>> Handle(
         IAuthenticationService authenticationService,
         [FromBody] LoginDto loginDto)
     {

--- a/src/SMAIAXBackend.API/Endpoints/Authentication/LogoutEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/Authentication/LogoutEndpoint.cs
@@ -8,11 +8,11 @@ namespace SMAIAXBackend.API.Endpoints.Authentication;
 
 public static class LogoutEndpoint
 {
-    public static async Task<Results<Ok, ProblemHttpResult>> Handle(
+    public static async Task<NoContent> Handle(
         IAuthenticationService authenticationService,
         [FromBody] TokenDto tokenDto)
     {
         await authenticationService.LogoutAsync(tokenDto.RefreshToken);
-        return TypedResults.Ok();
+        return TypedResults.NoContent();
     }
 }

--- a/src/SMAIAXBackend.API/Endpoints/Authentication/RefreshTokensEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/Authentication/RefreshTokensEndpoint.cs
@@ -8,7 +8,7 @@ namespace SMAIAXBackend.API.Endpoints.Authentication;
 
 public static class RefreshTokensEndpoint
 {
-    public static async Task<Results<Ok<TokenDto>, ProblemHttpResult>> Handle(
+    public static async Task<Ok<TokenDto>> Handle(
         IAuthenticationService authenticationService,
         [FromBody] TokenDto tokenDto)
     {

--- a/src/SMAIAXBackend.API/Endpoints/Authentication/RegisterEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/Authentication/RegisterEndpoint.cs
@@ -8,7 +8,7 @@ namespace SMAIAXBackend.API.Endpoints.Authentication;
 
 public static class RegisterEndpoint
 {
-    public static async Task<Results<Ok<Guid>, ProblemHttpResult>> Handle(
+    public static async Task<Ok<Guid>> Handle(
         IAuthenticationService authenticationService,
         [FromBody] RegisterDto registerDto)
     {

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/AddMetadataEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/AddMetadataEndpoint.cs
@@ -10,7 +10,7 @@ namespace SMAIAXBackend.API.Endpoints.SmartMeter;
 
 public static class AddMetadataEndpoint
 {
-    public static async Task<Results<Ok<Guid>, ProblemHttpResult>> Handle(
+    public static async Task<Ok<Guid>> Handle(
         ISmartMeterCreateService smartMeterCreateService,
         [FromRoute] Guid id,
         [FromBody] MetadataCreateDto metadataCreateDto,

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/AddSmartMeterEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/AddSmartMeterEndpoint.cs
@@ -10,7 +10,7 @@ namespace SMAIAXBackend.API.Endpoints.SmartMeter;
 
 public static class AddSmartMeterEndpoint
 {
-    public static async Task<Results<CreatedAtRoute, ProblemHttpResult>> Handle(
+    public static async Task<CreatedAtRoute> Handle(
         ISmartMeterCreateService smartMeterCreateService,
         ClaimsPrincipal user,
         [FromBody] SmartMeterCreateDto smartMeterCreateDto)

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/GetSmartMeterByIdEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/GetSmartMeterByIdEndpoint.cs
@@ -10,7 +10,7 @@ namespace SMAIAXBackend.API.Endpoints.SmartMeter;
 
 public static class GetSmartMeterByIdEndpoint
 {
-    public static async Task<Results<Ok<SmartMeterOverviewDto>, ProblemHttpResult>> Handle(
+    public static async Task<Ok<SmartMeterOverviewDto>> Handle(
         ISmartMeterListService smartMeterListService,
         ClaimsPrincipal user,
         [FromRoute] Guid id)

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/GetSmartMetersEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/GetSmartMetersEndpoint.cs
@@ -9,7 +9,7 @@ namespace SMAIAXBackend.API.Endpoints.SmartMeter;
 
 public static class GetSmartMetersEndpoint
 {
-    public static async Task<Results<Ok<List<SmartMeterOverviewDto>>, ProblemHttpResult>> Handle(
+    public static async Task<Ok<List<SmartMeterOverviewDto>>> Handle(
         ISmartMeterListService smartMeterListService,
         ClaimsPrincipal user)
     {

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/RemoveMetadataEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/RemoveMetadataEndpoint.cs
@@ -1,0 +1,23 @@
+using System.Security.Claims;
+
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+using SMAIAXBackend.Application.Services.Interfaces;
+
+namespace SMAIAXBackend.API.Endpoints.SmartMeter;
+
+public static class RemoveMetadataEndpoint
+{
+    public static async Task<NoContent> Handle(
+        ISmartMeterDeleteService smartMeterDeleteService,
+        [FromRoute] Guid smartMeterId,
+        [FromRoute] Guid metadataId,
+        ClaimsPrincipal user)
+    {
+        var userIdClaim = user.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
+        await smartMeterDeleteService.RemoveMetadataFromSmartMeterAsync(smartMeterId, metadataId, userIdClaim);
+
+        return TypedResults.NoContent();
+    }
+}

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/SmartMeterEndpoints.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/SmartMeterEndpoints.cs
@@ -52,6 +52,13 @@ public static class SmartMeterEndpoints
             .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesProblem(StatusCodes.Status500InternalServerError);
 
+        group.MapDelete("/{smartMeterId:guid}/metadata/{metadataId:guid}", RemoveMetadataEndpoint.Handle)
+            .WithName("removeMetadata")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
+
 
         return app;
     }

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/UpdateSmartMeterEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/UpdateSmartMeterEndpoint.cs
@@ -10,7 +10,7 @@ namespace SMAIAXBackend.API.Endpoints.SmartMeter;
 
 public static class UpdateSmartMeterEndpoint
 {
-    public static async Task<Results<Ok<Guid>, ProblemHttpResult>> Handle(
+    public static async Task<Ok<Guid>> Handle(
         ISmartMeterUpdateService smartMeterUpdateService,
         [FromRoute] Guid id,
         [FromBody] SmartMeterUpdateDto smartMeterUpdateDto,

--- a/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterDeleteService.cs
+++ b/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterDeleteService.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Logging;
+
+using SMAIAXBackend.Application.Exceptions;
+using SMAIAXBackend.Application.Services.Interfaces;
+using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
+using SMAIAXBackend.Domain.Repositories;
+
+namespace SMAIAXBackend.Application.Services.Implementations;
+
+public class SmartMeterDeleteService(
+    IUserValidationService userValidationService,
+    ISmartMeterRepository smartMeterRepository,
+    ILogger<SmartMeterDeleteService> logger) : ISmartMeterDeleteService
+{
+    public async Task RemoveMetadataFromSmartMeterAsync(Guid smartMeterId, Guid metadataId, string? userId)
+    {
+        var validatedUserId = await userValidationService.ValidateUserAsync(userId);
+        var smartMeter =
+            await smartMeterRepository.GetSmartMeterByIdAndUserIdAsync(new SmartMeterId(smartMeterId), validatedUserId);
+
+        if (smartMeter == null)
+        {
+            logger.LogWarning("SmartMeter with id {SmartMeterId} not found for user {UserId}", smartMeterId,
+                validatedUserId.Id);
+            throw new SmartMeterNotFoundException(smartMeterId, validatedUserId.Id);
+        }
+
+        smartMeter.RemoveMetadata(new MetadataId(metadataId));
+        await smartMeterRepository.UpdateAsync(smartMeter);
+    }
+}

--- a/src/SMAIAXBackend.Application/Services/Interfaces/ISmartMeterDeleteService.cs
+++ b/src/SMAIAXBackend.Application/Services/Interfaces/ISmartMeterDeleteService.cs
@@ -1,0 +1,6 @@
+namespace SMAIAXBackend.Application.Services.Interfaces;
+
+public interface ISmartMeterDeleteService
+{
+    Task RemoveMetadataFromSmartMeterAsync(Guid smartMeterId, Guid metadataId, string? userId);
+}

--- a/src/SMAIAXBackend.Domain/Model/Entities/SmartMeter.cs
+++ b/src/SMAIAXBackend.Domain/Model/Entities/SmartMeter.cs
@@ -45,6 +45,17 @@ public sealed class SmartMeter : IEquatable<SmartMeter>
         Metadata.Add(metadata);
     }
 
+    public void RemoveMetadata(MetadataId metadataId)
+    {
+        var metadata = Metadata.FirstOrDefault(m => m.Id.Equals(metadataId));
+        if (metadata == null)
+        {
+            throw new ArgumentException("Metadata not found");
+        }
+
+        Metadata.Remove(metadata);
+    }
+
     public void Update(string name)
     {
         Name = name;

--- a/tests/SMAIAXBackend.Application.UnitTests/SmartMeterDeleteServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/SmartMeterDeleteServiceTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using SMAIAXBackend.Application.Exceptions;
+using SMAIAXBackend.Application.Services.Implementations;
+using SMAIAXBackend.Application.Services.Interfaces;
+using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.Enums;
+using SMAIAXBackend.Domain.Model.ValueObjects;
+using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
+using SMAIAXBackend.Domain.Repositories;
+
+namespace SMAIAXBackend.Application.UnitTests;
+
+[TestFixture]
+public class SmartMeterDeleteServiceTests
+{
+    private Mock<IUserValidationService> _userValidationServiceMock;
+    private Mock<ISmartMeterRepository> _smartMeterRepositoryMock;
+    private Mock<ILogger<SmartMeterDeleteService>> _loggerMock;
+    private SmartMeterDeleteService _smartMeterDeleteService;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _userValidationServiceMock = new Mock<IUserValidationService>();
+        _smartMeterRepositoryMock = new Mock<ISmartMeterRepository>();
+        _loggerMock = new Mock<ILogger<SmartMeterDeleteService>>();
+        _smartMeterDeleteService = new SmartMeterDeleteService(
+            _userValidationServiceMock.Object,
+            _smartMeterRepositoryMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Test]
+    public async Task GivenSmartMeterIdAndMetadataIdAndUserId_WhenRemoveMetadataFromSmartMeter_ThenMetadataIsDeleted()
+    {
+        // Given
+        var userId = new UserId(Guid.NewGuid());
+        var smartMeter = SmartMeter.Create(new SmartMeterId(Guid.NewGuid()), "Smart Meter", userId);
+        var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
+            new Location("Some Streetnaame", "Some City", "Some State", "Some Country", Continent.Africa), 4,
+            smartMeter.Id);
+        smartMeter.AddMetadata(metadata);
+
+        _userValidationServiceMock.Setup(x => x.ValidateUserAsync(userId.Id.ToString())).ReturnsAsync(userId);
+        _smartMeterRepositoryMock.Setup(x => x.GetSmartMeterByIdAndUserIdAsync(It.IsAny<SmartMeterId>(), userId))
+            .ReturnsAsync(smartMeter);
+
+        // When
+        await _smartMeterDeleteService.RemoveMetadataFromSmartMeterAsync(smartMeter.Id.Id, metadata.Id.Id, userId.Id.ToString());
+
+        // Then
+        Assert.That(smartMeter.Metadata, Is.Empty);
+        _smartMeterRepositoryMock.Verify(x => x.UpdateAsync(smartMeter), Times.Once);
+    }
+
+    [Test]
+    public void GivenSmartMeterIdAndNonExistentMetadataIdAndUserId_WhenRemoveMetadataFromSmartMeter_ThenSmartMeterNotFoundExceptionIsThrown()
+    {
+        // Given
+        var userId = new UserId(Guid.NewGuid());
+        var smartMeterId = new SmartMeterId(Guid.NewGuid());
+        var metadataId = new MetadataId(Guid.NewGuid());
+
+        _userValidationServiceMock.Setup(x => x.ValidateUserAsync(userId.Id.ToString())).ReturnsAsync(userId);
+        _smartMeterRepositoryMock.Setup(x => x.GetSmartMeterByIdAndUserIdAsync(smartMeterId, userId))
+            .ReturnsAsync((SmartMeter)null!);
+
+        // When ... Then
+        Assert.ThrowsAsync<SmartMeterNotFoundException>(() =>
+            _smartMeterDeleteService.RemoveMetadataFromSmartMeterAsync(smartMeterId.Id, metadataId.Id, userId.Id.ToString()));
+    }
+}

--- a/tests/SMAIAXBackend.Domain.UnitTests/SmartMeterTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/SmartMeterTests.cs
@@ -76,4 +76,31 @@ public class SmartMeterTests
         smartMeter.AddMetadata(metadata);
         Assert.Throws<ArgumentException>(() => smartMeter.AddMetadata(metadata));
     }
+
+    [Test]
+    public void GivenSmartMeterAndMetadataId_WhenRemoveMetadata_ThenMetadataIsRemoved()
+    {
+        // Given
+        var smartMeter = SmartMeter.Create(new SmartMeterId(Guid.NewGuid()), "SmartMeter", new UserId(Guid.NewGuid()));
+        var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
+            new Location("Some street", "Some city", "Some state", "Some country", Continent.Europe),
+            4, smartMeter.Id);
+        smartMeter.AddMetadata(metadata);
+
+        // When
+        smartMeter.RemoveMetadata(metadata.Id);
+
+        // Then
+        Assert.That(smartMeter.Metadata, Is.Empty);
+    }
+
+    [Test]
+    public void GivenSmartMeterAndNonExistentMetadataId_WhenRemoveMetadata_ThenArgumentExceptionIsThrown()
+    {
+        // Given
+        var smartMeter = SmartMeter.Create(new SmartMeterId(Guid.NewGuid()), "SmartMeter", new UserId(Guid.NewGuid()));
+
+        // When ... Then
+        Assert.Throws<ArgumentException>(() => smartMeter.RemoveMetadata(new MetadataId(Guid.NewGuid())));
+    }
 }

--- a/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/AuthenticationTests.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/AuthenticationTests.cs
@@ -243,7 +243,7 @@ public class AuthenticationTests : TestBase
         var response = await _httpClient.PostAsync($"{BaseUrl}/logout", httpContent);
 
         // Then
-        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
 
         var invalidatedRefreshToken = await _applicationDbContext.RefreshTokens
             .AsNoTracking()

--- a/tests/SMAIAXBackend.IntegrationTests/TestBase.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/TestBase.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 
 using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.Enums;
 using SMAIAXBackend.Domain.Model.ValueObjects;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 using SMAIAXBackend.Domain.Repositories;
@@ -102,6 +103,10 @@ public class TestBase
             "Smart Meter 1", domainUser.Id);
         var smartMeter2 = SmartMeter.Create(new SmartMeterId(Guid.Parse("f4c70232-6715-4c15-966f-bf4bcef46d39")),
             "Smart Meter 2", domainUser.Id);
+        var smartMeter2Metadata = Metadata.Create(new MetadataId(Guid.Parse("1c8c8313-6fc4-4ebd-9ca8-8a1267441e06")),
+            DateTime.UtcNow, new Location("Some Streetname", "Some city", "Some state", "Some county", Continent.Asia),
+            4, smartMeter2.Id);
+        smartMeter2.AddMetadata(smartMeter2Metadata);
 
         await _applicationDbContext.Users.AddAsync(testUser);
         await _applicationDbContext.DomainUsers.AddAsync(domainUser);


### PR DESCRIPTION
- **feat(smartmeter): implement removing metadata from smart meter**
  - Implemented Delete endpoint to remove metadata from smart meter
  - Implemented RemoveMetadataFromSmartMeter method in SmartMeterDeleteService.
  - Implemented RemoveMetadata in SmartMeter.
  - Implemented unit and integration tests.
  

- **refactor(api): change return types of endpoints**
  - Changed the return types of the endpoints from `Results<>` to the actual return type because the http problem results are returned by the GlobalExceptionHandler.
  - Changed HTTP Statuscode from Ok to NoContent for Logout because it returns nothing.
  - Fixed integration test for logout endpoint to expect NoContent as HTTP Statuscode.
  