### PR TITLE
Policy Matching

### DIFF
--- a/src/SMAIAXBackend.API/ApplicationConfigurations/ServiceExtensions.cs
+++ b/src/SMAIAXBackend.API/ApplicationConfigurations/ServiceExtensions.cs
@@ -18,5 +18,6 @@ public static class ServiceExtensions
         services.AddScoped<ITenantContextService, TenantContextService>();
         services.AddScoped<IPolicyCreateService, PolicyCreateService>();
         services.AddScoped<IPolicyRequestCreateService, PolicyRequestCreateService>();
+        services.AddScoped<IPolicyMatchingService, PolicyMatchingService>();
     }
 }

--- a/src/SMAIAXBackend.API/Endpoints/PolicyRequest/CreatePolicyRequestEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/PolicyRequest/CreatePolicyRequestEndpoint.cs
@@ -8,12 +8,12 @@ namespace SMAIAXBackend.API.Endpoints.PolicyRequest;
 
 public static class CreatePolicyRequestEndpoint
 {
-    public static async Task<Ok<Guid>> Handle(
+    public static async Task<Ok<List<PolicyDto>>> Handle(
         IPolicyRequestCreateService policyRequestCreateService,
         [FromBody] PolicyRequestCreateDto policyRequestCreateDto)
     {
-        var policyRequestId = await policyRequestCreateService.CreatePolicyRequestAsync(policyRequestCreateDto);
+        var matchedPolicies = await policyRequestCreateService.CreatePolicyRequestAsync(policyRequestCreateDto);
 
-        return TypedResults.Ok(policyRequestId);
+        return TypedResults.Ok(matchedPolicies);
     }
 }

--- a/src/SMAIAXBackend.API/Endpoints/PolicyRequest/GetMatchingPoliciesEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/PolicyRequest/GetMatchingPoliciesEndpoint.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+using SMAIAXBackend.Application.DTOs;
+using SMAIAXBackend.Application.Services.Interfaces;
+
+namespace SMAIAXBackend.API.Endpoints.PolicyRequest;
+
+public static class GetMatchingPoliciesEndpoint
+{
+    public static async Task<Ok<List<PolicyDto>>> Handle(IPolicyMatchingService policyMatchingService, [FromRoute] Guid id)
+    {
+        var policies = await policyMatchingService.GetMatchingPoliciesAsync(id);
+
+        return TypedResults.Ok(policies);
+    }
+}

--- a/src/SMAIAXBackend.API/Endpoints/PolicyRequest/PolicyRequestEndpoints.cs
+++ b/src/SMAIAXBackend.API/Endpoints/PolicyRequest/PolicyRequestEndpoints.cs
@@ -19,6 +19,15 @@ public static class PolicyRequestEndpoints
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status500InternalServerError);
 
+        group.MapGet("/{id:guid}/policies", GetMatchingPoliciesEndpoint.Handle)
+            .WithName("getMatchingPolicies")
+            .Accepts<Guid>(contentType)
+            .Produces<List<PolicyDto>>(StatusCodes.Status200OK, contentType)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
+
         return app;
     }
 }

--- a/src/SMAIAXBackend.API/Endpoints/PolicyRequest/PolicyRequestEndpoints.cs
+++ b/src/SMAIAXBackend.API/Endpoints/PolicyRequest/PolicyRequestEndpoints.cs
@@ -14,7 +14,7 @@ public static class PolicyRequestEndpoints
         group.MapPost("/", CreatePolicyRequestEndpoint.Handle)
             .WithName("createPolicyRequest")
             .Accepts<PolicyRequestCreateDto>(contentType)
-            .Produces<Guid>(StatusCodes.Status200OK, contentType)
+            .Produces<List<PolicyDto>>(StatusCodes.Status200OK, contentType)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status500InternalServerError);

--- a/src/SMAIAXBackend.API/Middlewares/ExceptionHandlerMiddleware.cs
+++ b/src/SMAIAXBackend.API/Middlewares/ExceptionHandlerMiddleware.cs
@@ -16,6 +16,7 @@ public class ExceptionHandlerMiddleware : IExceptionHandler
 
         switch (exception)
         {
+            case PolicyRequestNotFoundException:
             case SmartMeterNotFoundException:
             case UserNotFoundException:
                 problemDetails.Type = "https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.5";

--- a/src/SMAIAXBackend.Application/DTOs/PolicyDto.cs
+++ b/src/SMAIAXBackend.Application/DTOs/PolicyDto.cs
@@ -1,0 +1,21 @@
+using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.Enums;
+
+namespace SMAIAXBackend.Application.DTOs;
+
+public class PolicyDto(
+    Guid id,
+    MeasurementResolution measurementResolution,
+    LocationResolution locationResolution,
+    decimal price)
+{
+    public Guid Id { get; set; } = id;
+    public MeasurementResolution MeasurementResolution { get; set; } = measurementResolution;
+    public LocationResolution LocationResolution { get; set; } = locationResolution;
+    public decimal Price { get; set; } = price;
+
+    public static PolicyDto FromPolicy(Policy policy)
+    {
+        return new PolicyDto(policy.Id.Id, policy.MeasurementResolution, policy.LocationResolution, policy.Price);
+    }
+}

--- a/src/SMAIAXBackend.Application/Exceptions/PolicyRequestNotFoundException.cs
+++ b/src/SMAIAXBackend.Application/Exceptions/PolicyRequestNotFoundException.cs
@@ -1,0 +1,6 @@
+namespace SMAIAXBackend.Application.Exceptions;
+
+public class PolicyRequestNotFoundException(Guid id) : Exception
+{
+    public override string Message { get; } = $"Policy request with id '{id}' not found.";
+}

--- a/src/SMAIAXBackend.Application/Services/Implementations/PolicyMatchingService.cs
+++ b/src/SMAIAXBackend.Application/Services/Implementations/PolicyMatchingService.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+
+using SMAIAXBackend.Application.DTOs;
+using SMAIAXBackend.Application.Exceptions;
+using SMAIAXBackend.Application.Services.Interfaces;
+using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
+using SMAIAXBackend.Domain.Repositories;
+using SMAIAXBackend.Domain.Specifications;
+
+namespace SMAIAXBackend.Application.Services.Implementations;
+
+public class PolicyMatchingService(
+    IPolicyRequestRepository policyRequestRepository,
+    ITenantRepository tenantRepository,
+    IPolicyRepository policyRepository,
+    ITenantContextService tenantContextService,
+    ILogger<PolicyMatchingService> logger) : IPolicyMatchingService
+{
+    public async Task<List<PolicyDto>> GetMatchingPoliciesAsync(Guid policyRequestId)
+    {
+        var matchingPolices = new List<PolicyDto>();
+
+        PolicyRequest? policyRequest =
+            await policyRequestRepository.GetPolicyRequestByIdAsync(new PolicyRequestId(policyRequestId));
+
+        if (policyRequest == null)
+        {
+            logger.LogWarning("Policy request with id {PolicyRequestId} not found", policyRequestId);
+            throw new PolicyRequestNotFoundException(policyRequestId);
+        }
+
+        var currentTenant = await tenantContextService.GetCurrentTenantAsync();
+        var tenants = await tenantRepository.GetAllAsync();
+        var specification = new PolicyMatchesRequestSpecification(policyRequest);
+        foreach (var tenant in tenants)
+        {
+            if (currentTenant.Equals(tenant))
+            {
+                continue;
+            }
+
+            var policies = await policyRepository.GetPoliciesByTenantAsync(tenant);
+            matchingPolices.AddRange(from policy in policies
+                                     where specification.IsSatisfiedBy(policy)
+                                     select PolicyDto.FromPolicy(policy));
+        }
+
+        return matchingPolices;
+    }
+}

--- a/src/SMAIAXBackend.Application/Services/Implementations/PolicyRequestCreateService.cs
+++ b/src/SMAIAXBackend.Application/Services/Implementations/PolicyRequestCreateService.cs
@@ -3,14 +3,19 @@ using SMAIAXBackend.Application.Services.Interfaces;
 using SMAIAXBackend.Domain.Model.Entities;
 using SMAIAXBackend.Domain.Model.ValueObjects;
 using SMAIAXBackend.Domain.Repositories;
+using SMAIAXBackend.Domain.Specifications;
 
 namespace SMAIAXBackend.Application.Services.Implementations;
 
 public class PolicyRequestCreateService(
-    IPolicyRequestRepository policyRequestRepository) : IPolicyRequestCreateService
+    IPolicyRequestRepository policyRequestRepository,
+    ITenantRepository tenantRepository,
+    IPolicyRepository policyRepository,
+    ITenantContextService tenantContextService) : IPolicyRequestCreateService
 {
-    public async Task<Guid> CreatePolicyRequestAsync(PolicyRequestCreateDto policyRequestCreateDto)
+    public async Task<List<PolicyDto>> CreatePolicyRequestAsync(PolicyRequestCreateDto policyRequestCreateDto)
     {
+        var matchingPolices = new List<PolicyDto>();
         var policyRequestId = policyRequestRepository.NextIdentity();
 
         var locations = new List<Location>();
@@ -31,9 +36,22 @@ public class PolicyRequestCreateService(
 
         var policyRequest = PolicyRequest.Create(policyRequestId, policyRequestCreateDto.IsAutomaticContractingEnabled,
             policyFilter);
-
         await policyRequestRepository.AddAsync(policyRequest);
 
-        return policyRequestId.Id;
+        var currentTenant = await tenantContextService.GetCurrentTenantAsync();
+        var tenants = await tenantRepository.GetAllAsync();
+        var specification = new PolicyMatchesRequestSpecification(policyRequest);
+        foreach (var tenant in tenants)
+        {
+            if (currentTenant.Equals(tenant))
+            {
+                continue;
+            }
+
+            var policies = await policyRepository.GetPoliciesByTenantAsync(tenant);
+            matchingPolices.AddRange(from policy in policies where specification.IsSatisfiedBy(policy) select PolicyDto.FromPolicy(policy));
+        }
+
+        return matchingPolices;
     }
 }

--- a/src/SMAIAXBackend.Application/Services/Interfaces/IPolicyMatchingService.cs
+++ b/src/SMAIAXBackend.Application/Services/Interfaces/IPolicyMatchingService.cs
@@ -1,0 +1,8 @@
+using SMAIAXBackend.Application.DTOs;
+
+namespace SMAIAXBackend.Application.Services.Interfaces;
+
+public interface IPolicyMatchingService
+{
+    Task<List<PolicyDto>> GetMatchingPoliciesAsync(Guid policyRequestId);
+}

--- a/src/SMAIAXBackend.Application/Services/Interfaces/IPolicyRequestCreateService.cs
+++ b/src/SMAIAXBackend.Application/Services/Interfaces/IPolicyRequestCreateService.cs
@@ -4,5 +4,5 @@ namespace SMAIAXBackend.Application.Services.Interfaces;
 
 public interface IPolicyRequestCreateService
 {
-    Task<Guid> CreatePolicyRequestAsync(PolicyRequestCreateDto policyRequestCreateDto);
+    Task<List<PolicyDto>> CreatePolicyRequestAsync(PolicyRequestCreateDto policyRequestCreateDto);
 }

--- a/src/SMAIAXBackend.Domain/Repositories/IPolicyRepository.cs
+++ b/src/SMAIAXBackend.Domain/Repositories/IPolicyRepository.cs
@@ -8,4 +8,5 @@ public interface IPolicyRepository
     PolicyId NextIdentity();
     Task AddAsync(Policy policy);
     Task<List<Policy>> GetPoliciesBySmartMeterIdAsync(SmartMeterId smartMeterId);
+    Task<List<Policy>> GetPoliciesByTenantAsync(Tenant tenant);
 }

--- a/src/SMAIAXBackend.Domain/Repositories/IPolicyRequestRepository.cs
+++ b/src/SMAIAXBackend.Domain/Repositories/IPolicyRequestRepository.cs
@@ -7,4 +7,5 @@ public interface IPolicyRequestRepository
 {
     PolicyRequestId NextIdentity();
     Task AddAsync(PolicyRequest policyRequest);
+    Task<PolicyRequest?> GetPolicyRequestByIdAsync(PolicyRequestId id);
 }

--- a/src/SMAIAXBackend.Domain/Repositories/ITenantRepository.cs
+++ b/src/SMAIAXBackend.Domain/Repositories/ITenantRepository.cs
@@ -9,5 +9,6 @@ public interface ITenantRepository
     Task AddAsync(Tenant tenant);
     Task DeleteAsync(Tenant tenant);
     Task<Tenant?> GetByIdAsync(TenantId tenantId);
+    Task<List<Tenant>> GetAllAsync();
     Task CreateDatabaseForTenantAsync(string databaseName, string databaseUserName, string databasePassword);
 }

--- a/src/SMAIAXBackend.Domain/Specifications/ISpecification.cs
+++ b/src/SMAIAXBackend.Domain/Specifications/ISpecification.cs
@@ -1,0 +1,6 @@
+namespace SMAIAXBackend.Domain.Specifications;
+
+public interface ISpecification<in T>
+{
+    bool IsSatisfiedBy(T entity);
+}

--- a/src/SMAIAXBackend.Domain/Specifications/MeasurementResolutionSpecification.cs
+++ b/src/SMAIAXBackend.Domain/Specifications/MeasurementResolutionSpecification.cs
@@ -1,0 +1,12 @@
+using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.Enums;
+
+namespace SMAIAXBackend.Domain.Specifications;
+
+public class MeasurementResolutionSpecification(MeasurementResolution measurementResolution) : ISpecification<Policy>
+{
+    public bool IsSatisfiedBy(Policy policy)
+    {
+        return policy.MeasurementResolution <= measurementResolution;
+    }
+}

--- a/src/SMAIAXBackend.Domain/Specifications/PolicyMatchesRequestSpecification.cs
+++ b/src/SMAIAXBackend.Domain/Specifications/PolicyMatchesRequestSpecification.cs
@@ -1,0 +1,17 @@
+using SMAIAXBackend.Domain.Model.Entities;
+
+namespace SMAIAXBackend.Domain.Specifications;
+
+public class PolicyMatchesRequestSpecification(PolicyRequest policyRequest) : ISpecification<Policy>
+{
+    private readonly List<ISpecification<Policy>> _specifications =
+    [
+        new PriceSpecification(policyRequest.PolicyFilter.MaxPrice),
+        new MeasurementResolutionSpecification(policyRequest.PolicyFilter.MeasurementResolution)
+    ];
+
+    public bool IsSatisfiedBy(Policy policy)
+    {
+        return _specifications.TrueForAll(specification => specification.IsSatisfiedBy(policy));
+    }
+}

--- a/src/SMAIAXBackend.Domain/Specifications/PriceSpecification.cs
+++ b/src/SMAIAXBackend.Domain/Specifications/PriceSpecification.cs
@@ -1,0 +1,11 @@
+using SMAIAXBackend.Domain.Model.Entities;
+
+namespace SMAIAXBackend.Domain.Specifications;
+
+public class PriceSpecification(decimal maxPrice) : ISpecification<Policy>
+{
+    public bool IsSatisfiedBy(Policy policy)
+    {
+        return policy.Price <= maxPrice;
+    }
+}

--- a/src/SMAIAXBackend.Infrastructure/Repositories/PolicyRequestRepository.cs
+++ b/src/SMAIAXBackend.Infrastructure/Repositories/PolicyRequestRepository.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+
 using SMAIAXBackend.Domain.Model.Entities;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 using SMAIAXBackend.Domain.Repositories;
@@ -16,5 +18,11 @@ public class PolicyRequestRepository(TenantDbContext tenantDbContext) : IPolicyR
     {
         await tenantDbContext.PolicyRequests.AddAsync(policyRequest);
         await tenantDbContext.SaveChangesAsync();
+    }
+
+    public async Task<PolicyRequest?> GetPolicyRequestByIdAsync(PolicyRequestId id)
+    {
+        return await tenantDbContext.PolicyRequests
+            .FirstOrDefaultAsync(pr => pr.Id.Equals(id));
     }
 }

--- a/src/SMAIAXBackend.Infrastructure/Repositories/TenantRepository.cs
+++ b/src/SMAIAXBackend.Infrastructure/Repositories/TenantRepository.cs
@@ -36,6 +36,11 @@ public class TenantRepository(
         return await applicationDbContext.Tenants.FindAsync(tenantId);
     }
 
+    public async Task<List<Tenant>> GetAllAsync()
+    {
+        return await applicationDbContext.Tenants.ToListAsync();
+    }
+
     public async Task CreateDatabaseForTenantAsync(
         string databaseName,
         string databaseUserName,

--- a/tests/SMAIAXBackend.Application.UnitTests/PolicyMatchingServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/PolicyMatchingServiceTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using SMAIAXBackend.Application.Services.Implementations;
+using SMAIAXBackend.Application.Services.Interfaces;
+using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.Enums;
+using SMAIAXBackend.Domain.Model.ValueObjects;
+using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
+using SMAIAXBackend.Domain.Repositories;
+
+namespace SMAIAXBackend.Application.UnitTests;
+
+[TestFixture]
+public class PolicyMatchingServiceTests
+{
+    private Mock<IPolicyRequestRepository> _policyRequestRepositoryMock;
+    private Mock<ITenantRepository> _tenantRepositoryMock;
+    private Mock<IPolicyRepository> _policyRepositoryMock;
+    private Mock<ITenantContextService> _tenantContextServiceMock;
+    private Mock<ILogger<PolicyMatchingService>> _loggerMock;
+    private PolicyMatchingService _policyMatchingService;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _policyRequestRepositoryMock = new Mock<IPolicyRequestRepository>();
+        _tenantRepositoryMock = new Mock<ITenantRepository>();
+        _policyRepositoryMock = new Mock<IPolicyRepository>();
+        _tenantContextServiceMock = new Mock<ITenantContextService>();
+        _loggerMock = new Mock<ILogger<PolicyMatchingService>>();
+        _policyMatchingService = new PolicyMatchingService(
+            _policyRequestRepositoryMock.Object,
+            _tenantRepositoryMock.Object,
+            _policyRepositoryMock.Object,
+            _tenantContextServiceMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Test]
+    public async Task GivenPolicyRequestId_WhenGetMatchingPolicies_ThenMatchingPoliciesAreReturned()
+    {
+        // Given
+        const int policyCountExpected = 1;
+        var policyRequestId = new PolicyRequestId(Guid.NewGuid());
+        var policyFilter = new PolicyFilter(MeasurementResolution.Hour, 1, 5, [], LocationResolution.State, 100);
+        var policyRequest = PolicyRequest.Create(policyRequestId, false, policyFilter);
+        var tenants = new List<Tenant>
+        {
+            Tenant.Create(
+                id: new TenantId(Guid.NewGuid()),
+                databaseUsername: "test",
+                databasePassword: "test",
+                databaseName: "test"
+            ),
+            Tenant.Create(
+                id: new TenantId(Guid.NewGuid()),
+                databaseUsername: "test2",
+                databasePassword: "test2",
+                databaseName: "test2"
+            )
+        };
+
+        var policies = new List<Policy>
+        {
+            Policy.Create(
+                id: new PolicyId(Guid.NewGuid()),
+                measurementResolution: MeasurementResolution.Hour,
+                locationResolution: LocationResolution.State,
+                price: 50,
+                smartMeterId: new SmartMeterId(Guid.NewGuid())
+            ),
+            Policy.Create(
+                id: new PolicyId(Guid.NewGuid()),
+                measurementResolution: MeasurementResolution.Hour,
+                locationResolution: LocationResolution.State,
+                price: 150,
+                smartMeterId: new SmartMeterId(Guid.NewGuid())
+            )
+        };
+
+        _policyRequestRepositoryMock.Setup(x => x.GetPolicyRequestByIdAsync(policyRequestId))
+            .ReturnsAsync(policyRequest);
+        _tenantContextServiceMock.Setup(service => service.GetCurrentTenantAsync()).ReturnsAsync(tenants[0]);
+        _tenantRepositoryMock.Setup(repo => repo.GetAllAsync()).ReturnsAsync(tenants);
+        _policyRepositoryMock.Setup(repo => repo.GetPoliciesByTenantAsync(tenants[1])).ReturnsAsync(policies);
+
+        // When
+        var matchingPolicies = await _policyMatchingService.GetMatchingPoliciesAsync(policyRequestId.Id);
+
+        // Then
+        Assert.That(matchingPolicies, Is.Not.Empty);
+        Assert.That(matchingPolicies, Has.Count.EqualTo(policyCountExpected));
+        Assert.That(matchingPolicies[0].Id, Is.EqualTo(policies[0].Id.Id));
+    }
+}

--- a/tests/SMAIAXBackend.Application.UnitTests/PolicyRequestCreateServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/PolicyRequestCreateServiceTests.cs
@@ -2,6 +2,7 @@ using Moq;
 
 using SMAIAXBackend.Application.DTOs;
 using SMAIAXBackend.Application.Services.Implementations;
+using SMAIAXBackend.Application.Services.Interfaces;
 using SMAIAXBackend.Domain.Model.Entities;
 using SMAIAXBackend.Domain.Model.Enums;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
@@ -13,18 +14,25 @@ namespace SMAIAXBackend.Application.UnitTests;
 public class PolicyRequestCreateServiceTests
 {
     private Mock<IPolicyRequestRepository> _policyRequestRepositoryMock;
+    private Mock<ITenantRepository> _tenantRepositoryMock;
+    private Mock<IPolicyRepository> _policyRepositoryMock;
+    private Mock<ITenantContextService> _tenantContextServiceMock;
     private PolicyRequestCreateService _policyRequestCreateService;
 
     [SetUp]
     public void Setup()
     {
         _policyRequestRepositoryMock = new Mock<IPolicyRequestRepository>();
+        _tenantRepositoryMock = new Mock<ITenantRepository>();
+        _policyRepositoryMock = new Mock<IPolicyRepository>();
+        _tenantContextServiceMock = new Mock<ITenantContextService>();
         _policyRequestCreateService =
-            new PolicyRequestCreateService(_policyRequestRepositoryMock.Object);
+            new PolicyRequestCreateService(_policyRequestRepositoryMock.Object, _tenantRepositoryMock.Object,
+                _policyRepositoryMock.Object, _tenantContextServiceMock.Object);
     }
 
     [Test]
-    public async Task GivenPolicyRequestCreateDtoAndExistentUserId_WhenCreatePolicyRequest_ThenPolicyRequestIdIsReturned()
+    public async Task GivenPolicyRequestCreateDtoAndExistentUserId_WhenCreatePolicyRequest_ThenMatchingPoliciesAreReturned()
     {
         // Given
         var policyRequestIdExpected = new PolicyRequestId(Guid.NewGuid());
@@ -45,14 +53,49 @@ public class PolicyRequestCreateServiceTests
             ],
             locationResolution: LocationResolution.State,
             maxPrice: 100);
+        var tenants = new List<Tenant>
+        {
+            Tenant.Create(
+                id: new TenantId(Guid.NewGuid()),
+                databaseUsername: "test",
+                databasePassword: "test",
+                databaseName: "test"
+            ),
+            Tenant.Create(
+                id: new TenantId(Guid.NewGuid()),
+                databaseUsername: "test2",
+                databasePassword: "test2",
+                databaseName: "test2"
+            )
+        };
+
+        var policies = new List<Policy>
+        {
+            Policy.Create(
+                id: new PolicyId(Guid.NewGuid()),
+                measurementResolution: MeasurementResolution.Hour,
+                locationResolution: LocationResolution.State,
+                price: 50,
+                smartMeterId: new SmartMeterId(Guid.NewGuid())
+            ),
+            Policy.Create(
+                id: new PolicyId(Guid.NewGuid()),
+                measurementResolution: MeasurementResolution.Hour,
+                locationResolution: LocationResolution.State,
+                price: 150,
+                smartMeterId: new SmartMeterId(Guid.NewGuid())
+            )
+        };
 
         _policyRequestRepositoryMock.Setup(repo => repo.NextIdentity()).Returns(policyRequestIdExpected);
+        _tenantContextServiceMock.Setup(service => service.GetCurrentTenantAsync()).ReturnsAsync(tenants[0]);
+        _tenantRepositoryMock.Setup(repo => repo.GetAllAsync()).ReturnsAsync(tenants);
+        _policyRepositoryMock.Setup(repo => repo.GetPoliciesByTenantAsync(tenants[1])).ReturnsAsync(policies);
 
         // When
-        var policyRequestIdActual = await _policyRequestCreateService.CreatePolicyRequestAsync(policyRequestCreateDto);
+        var matchingPolicies = await _policyRequestCreateService.CreatePolicyRequestAsync(policyRequestCreateDto);
 
         // Then
-        Assert.That(policyRequestIdActual, Is.EqualTo(policyRequestIdExpected.Id));
-        _policyRequestRepositoryMock.Verify(repo => repo.AddAsync(It.IsAny<PolicyRequest>()), Times.Once);
+        Assert.That(matchingPolicies, Is.Not.Empty);
     }
 }

--- a/tests/SMAIAXBackend.Application.UnitTests/PolicyRequestCreateServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/PolicyRequestCreateServiceTests.cs
@@ -3,7 +3,6 @@ using Moq;
 using SMAIAXBackend.Application.DTOs;
 using SMAIAXBackend.Application.Services.Implementations;
 using SMAIAXBackend.Application.Services.Interfaces;
-using SMAIAXBackend.Domain.Model.Entities;
 using SMAIAXBackend.Domain.Model.Enums;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 using SMAIAXBackend.Domain.Repositories;
@@ -14,21 +13,16 @@ namespace SMAIAXBackend.Application.UnitTests;
 public class PolicyRequestCreateServiceTests
 {
     private Mock<IPolicyRequestRepository> _policyRequestRepositoryMock;
-    private Mock<ITenantRepository> _tenantRepositoryMock;
-    private Mock<IPolicyRepository> _policyRepositoryMock;
-    private Mock<ITenantContextService> _tenantContextServiceMock;
+    private Mock<IPolicyMatchingService> _policyMatchingServiceMock;
     private PolicyRequestCreateService _policyRequestCreateService;
 
     [SetUp]
     public void Setup()
     {
         _policyRequestRepositoryMock = new Mock<IPolicyRequestRepository>();
-        _tenantRepositoryMock = new Mock<ITenantRepository>();
-        _policyRepositoryMock = new Mock<IPolicyRepository>();
-        _tenantContextServiceMock = new Mock<ITenantContextService>();
+        _policyMatchingServiceMock = new Mock<IPolicyMatchingService>();
         _policyRequestCreateService =
-            new PolicyRequestCreateService(_policyRequestRepositoryMock.Object, _tenantRepositoryMock.Object,
-                _policyRepositoryMock.Object, _tenantContextServiceMock.Object);
+            new PolicyRequestCreateService(_policyRequestRepositoryMock.Object, _policyMatchingServiceMock.Object);
     }
 
     [Test]
@@ -53,44 +47,16 @@ public class PolicyRequestCreateServiceTests
             ],
             locationResolution: LocationResolution.State,
             maxPrice: 100);
-        var tenants = new List<Tenant>
-        {
-            Tenant.Create(
-                id: new TenantId(Guid.NewGuid()),
-                databaseUsername: "test",
-                databasePassword: "test",
-                databaseName: "test"
-            ),
-            Tenant.Create(
-                id: new TenantId(Guid.NewGuid()),
-                databaseUsername: "test2",
-                databasePassword: "test2",
-                databaseName: "test2"
-            )
-        };
 
-        var policies = new List<Policy>
+        var policies = new List<PolicyDto>
         {
-            Policy.Create(
-                id: new PolicyId(Guid.NewGuid()),
-                measurementResolution: MeasurementResolution.Hour,
-                locationResolution: LocationResolution.State,
-                price: 50,
-                smartMeterId: new SmartMeterId(Guid.NewGuid())
-            ),
-            Policy.Create(
-                id: new PolicyId(Guid.NewGuid()),
-                measurementResolution: MeasurementResolution.Hour,
-                locationResolution: LocationResolution.State,
-                price: 150,
-                smartMeterId: new SmartMeterId(Guid.NewGuid())
-            )
+            new(Guid.NewGuid(), MeasurementResolution.Hour, LocationResolution.State, 50),
+            new(Guid.NewGuid(), MeasurementResolution.Hour, LocationResolution.State, 150),
         };
 
         _policyRequestRepositoryMock.Setup(repo => repo.NextIdentity()).Returns(policyRequestIdExpected);
-        _tenantContextServiceMock.Setup(service => service.GetCurrentTenantAsync()).ReturnsAsync(tenants[0]);
-        _tenantRepositoryMock.Setup(repo => repo.GetAllAsync()).ReturnsAsync(tenants);
-        _policyRepositoryMock.Setup(repo => repo.GetPoliciesByTenantAsync(tenants[1])).ReturnsAsync(policies);
+        _policyMatchingServiceMock.Setup(service => service.GetMatchingPoliciesAsync(policyRequestIdExpected.Id))
+            .ReturnsAsync(policies);
 
         // When
         var matchingPolicies = await _policyRequestCreateService.CreatePolicyRequestAsync(policyRequestCreateDto);

--- a/tests/SMAIAXBackend.Domain.UnitTests/Model/ContractTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Model/ContractTests.cs
@@ -1,7 +1,7 @@
 using SMAIAXBackend.Domain.Model.Entities;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 
-namespace SMAIAXBackend.Domain.UnitTests;
+namespace SMAIAXBackend.Domain.UnitTests.Model;
 
 [TestFixture]
 public class ContractTests

--- a/tests/SMAIAXBackend.Domain.UnitTests/Model/MeasurementTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Model/MeasurementTests.cs
@@ -2,7 +2,7 @@ using SMAIAXBackend.Domain.Model.Entities;
 using SMAIAXBackend.Domain.Model.ValueObjects;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 
-namespace SMAIAXBackend.Domain.UnitTests;
+namespace SMAIAXBackend.Domain.UnitTests.Model;
 
 [TestFixture]
 public class MeasurementTests

--- a/tests/SMAIAXBackend.Domain.UnitTests/Model/MetadataTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Model/MetadataTests.cs
@@ -3,7 +3,7 @@ using SMAIAXBackend.Domain.Model.Enums;
 using SMAIAXBackend.Domain.Model.ValueObjects;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 
-namespace SMAIAXBackend.Domain.UnitTests;
+namespace SMAIAXBackend.Domain.UnitTests.Model;
 
 [TestFixture]
 public class MetadataTests

--- a/tests/SMAIAXBackend.Domain.UnitTests/Model/PolicyRequestTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Model/PolicyRequestTests.cs
@@ -3,7 +3,7 @@ using SMAIAXBackend.Domain.Model.Enums;
 using SMAIAXBackend.Domain.Model.ValueObjects;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 
-namespace SMAIAXBackend.Domain.UnitTests;
+namespace SMAIAXBackend.Domain.UnitTests.Model;
 
 [TestFixture]
 public class PolicyRequestTests

--- a/tests/SMAIAXBackend.Domain.UnitTests/Model/PolicyTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Model/PolicyTests.cs
@@ -2,7 +2,7 @@ using SMAIAXBackend.Domain.Model.Entities;
 using SMAIAXBackend.Domain.Model.Enums;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 
-namespace SMAIAXBackend.Domain.UnitTests;
+namespace SMAIAXBackend.Domain.UnitTests.Model;
 
 [TestFixture]
 public class PolicyTests

--- a/tests/SMAIAXBackend.Domain.UnitTests/Model/RefreshTokenTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Model/RefreshTokenTests.cs
@@ -1,7 +1,7 @@
 using SMAIAXBackend.Domain.Model.Entities;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 
-namespace SMAIAXBackend.Domain.UnitTests;
+namespace SMAIAXBackend.Domain.UnitTests.Model;
 
 [TestFixture]
 public class RefreshTokenTests

--- a/tests/SMAIAXBackend.Domain.UnitTests/Model/SmartMeterTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Model/SmartMeterTests.cs
@@ -3,7 +3,7 @@ using SMAIAXBackend.Domain.Model.Enums;
 using SMAIAXBackend.Domain.Model.ValueObjects;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 
-namespace SMAIAXBackend.Domain.UnitTests;
+namespace SMAIAXBackend.Domain.UnitTests.Model;
 
 [TestFixture]
 public class SmartMeterTests

--- a/tests/SMAIAXBackend.Domain.UnitTests/Model/UserTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Model/UserTests.cs
@@ -2,7 +2,7 @@ using SMAIAXBackend.Domain.Model.Entities;
 using SMAIAXBackend.Domain.Model.ValueObjects;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 
-namespace SMAIAXBackend.Domain.UnitTests;
+namespace SMAIAXBackend.Domain.UnitTests.Model;
 
 [TestFixture]
 public class UserTests

--- a/tests/SMAIAXBackend.Domain.UnitTests/Specifications/MeasurementResolutionSpecificationTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Specifications/MeasurementResolutionSpecificationTests.cs
@@ -15,14 +15,14 @@ public class MeasurementResolutionSpecificationTests
         var specification = new MeasurementResolutionSpecification(MeasurementResolution.Day);
         var policy = Policy.Create(new PolicyId(Guid.NewGuid()), MeasurementResolution.Day, LocationResolution.Country,
             100, new SmartMeterId(Guid.NewGuid()));
-        
+
         // When
         var result = specification.IsSatisfiedBy(policy);
-        
+
         // Then
         Assert.That(result, Is.True);
     }
-    
+
     [Test]
     public void Given_MeasurementResolutionIsLower_When_IsSatisfiedByIsCalled_Then_ReturnsTrue()
     {
@@ -37,7 +37,7 @@ public class MeasurementResolutionSpecificationTests
         // Then
         Assert.That(result, Is.True);
     }
-    
+
     [Test]
     public void Given_MeasurementResolutionIsHigher_When_IsSatisfiedByIsCalled_Then_ReturnsFalse()
     {

--- a/tests/SMAIAXBackend.Domain.UnitTests/Specifications/MeasurementResolutionSpecificationTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Specifications/MeasurementResolutionSpecificationTests.cs
@@ -1,0 +1,55 @@
+using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.Enums;
+using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
+using SMAIAXBackend.Domain.Specifications;
+
+namespace SMAIAXBackend.Domain.UnitTests.Specifications;
+
+[TestFixture]
+public class MeasurementResolutionSpecificationTests
+{
+    [Test]
+    public void Given_MeasurementResolutionIsEqual_When_IsSatisfiedByIsCalled_Then_ReturnsTrue()
+    {
+        // Given
+        var specification = new MeasurementResolutionSpecification(MeasurementResolution.Day);
+        var policy = Policy.Create(new PolicyId(Guid.NewGuid()), MeasurementResolution.Day, LocationResolution.Country,
+            100, new SmartMeterId(Guid.NewGuid()));
+        
+        // When
+        var result = specification.IsSatisfiedBy(policy);
+        
+        // Then
+        Assert.That(result, Is.True);
+    }
+    
+    [Test]
+    public void Given_MeasurementResolutionIsLower_When_IsSatisfiedByIsCalled_Then_ReturnsTrue()
+    {
+        // Given
+        var specification = new MeasurementResolutionSpecification(MeasurementResolution.Day);
+        var policy = Policy.Create(new PolicyId(Guid.NewGuid()), MeasurementResolution.Hour, LocationResolution.Country,
+            100, new SmartMeterId(Guid.NewGuid()));
+
+        // When
+        var result = specification.IsSatisfiedBy(policy);
+
+        // Then
+        Assert.That(result, Is.True);
+    }
+    
+    [Test]
+    public void Given_MeasurementResolutionIsHigher_When_IsSatisfiedByIsCalled_Then_ReturnsFalse()
+    {
+        // Given
+        var specification = new MeasurementResolutionSpecification(MeasurementResolution.Hour);
+        var policy = Policy.Create(new PolicyId(Guid.NewGuid()), MeasurementResolution.Day, LocationResolution.Country,
+            100, new SmartMeterId(Guid.NewGuid()));
+
+        // When
+        var result = specification.IsSatisfiedBy(policy);
+
+        // Then
+        Assert.That(result, Is.False);
+    }
+}

--- a/tests/SMAIAXBackend.Domain.UnitTests/Specifications/PolicyMatchesRequestSpecificationTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Specifications/PolicyMatchesRequestSpecificationTests.cs
@@ -1,0 +1,62 @@
+using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.Enums;
+using SMAIAXBackend.Domain.Model.ValueObjects;
+using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
+using SMAIAXBackend.Domain.Specifications;
+
+namespace SMAIAXBackend.Domain.UnitTests.Specifications;
+
+[TestFixture]
+public class PolicyMatchesRequestSpecificationTests
+{
+    [Test]
+    public void Given_PolicyMatchesRequestCriteria_When_IsSatisfiedByIsCalled_Then_ReturnsTrue()
+    {
+        // Given
+        var policyFilter = new PolicyFilter(MeasurementResolution.Hour, 1, 4, [], LocationResolution.Country, 100);
+        var policyRequest = PolicyRequest.Create(new PolicyRequestId(Guid.NewGuid()), false, policyFilter);
+        var specification = new PolicyMatchesRequestSpecification(policyRequest);
+        var policy = Policy.Create(new PolicyId(Guid.NewGuid()), MeasurementResolution.Hour, LocationResolution.Country,
+            90, new SmartMeterId(Guid.NewGuid()));
+        
+        // When
+        var result = specification.IsSatisfiedBy(policy);
+
+        // Then
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Given_PolicyDoesNotMatchPriceCriteria_When_IsSatisfiedByIsCalled_Then_ReturnsFalse()
+    {
+        // Given
+        var policyFilter = new PolicyFilter(MeasurementResolution.Hour, 1, 4, [], LocationResolution.Country, 100);
+        var policyRequest = PolicyRequest.Create(new PolicyRequestId(Guid.NewGuid()), false, policyFilter);
+        var specification = new PolicyMatchesRequestSpecification(policyRequest);
+        var policy = Policy.Create(new PolicyId(Guid.NewGuid()), MeasurementResolution.Hour, LocationResolution.Country,
+            110, new SmartMeterId(Guid.NewGuid()));
+
+        // When
+        var result = specification.IsSatisfiedBy(policy);
+
+        // Then
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Given_PolicyDoesNotMatchResolutionCriteria_When_IsSatisfiedByIsCalled_Then_ReturnsFalse()
+    {
+        // Given
+        var policyFilter = new PolicyFilter(MeasurementResolution.Hour, 1, 4, [], LocationResolution.Country, 100);
+        var policyRequest = PolicyRequest.Create(new PolicyRequestId(Guid.NewGuid()), false, policyFilter);
+        var specification = new PolicyMatchesRequestSpecification(policyRequest);
+        var policy = Policy.Create(new PolicyId(Guid.NewGuid()), MeasurementResolution.Day, LocationResolution.Country,
+            90, new SmartMeterId(Guid.NewGuid()));
+
+        // When
+        var result = specification.IsSatisfiedBy(policy);
+
+        // Then
+        Assert.That(result, Is.False);
+    }
+}

--- a/tests/SMAIAXBackend.Domain.UnitTests/Specifications/PolicyMatchesRequestSpecificationTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Specifications/PolicyMatchesRequestSpecificationTests.cs
@@ -18,7 +18,7 @@ public class PolicyMatchesRequestSpecificationTests
         var specification = new PolicyMatchesRequestSpecification(policyRequest);
         var policy = Policy.Create(new PolicyId(Guid.NewGuid()), MeasurementResolution.Hour, LocationResolution.Country,
             90, new SmartMeterId(Guid.NewGuid()));
-        
+
         // When
         var result = specification.IsSatisfiedBy(policy);
 

--- a/tests/SMAIAXBackend.Domain.UnitTests/Specifications/PriceSpecificationTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Specifications/PriceSpecificationTests.cs
@@ -1,0 +1,55 @@
+using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.Enums;
+using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
+using SMAIAXBackend.Domain.Specifications;
+
+namespace SMAIAXBackend.Domain.UnitTests.Specifications;
+
+[TestFixture]
+public class PriceSpecificationTests
+{
+    [Test]
+    public void Given_PriceIsEqualToMaxPrice_When_IsSatisfiedByIsCalled_Then_ReturnsTrue()
+    {
+        // Given
+        var specification = new PriceSpecification(100);
+        var policy = Policy.Create(new PolicyId(Guid.NewGuid()), MeasurementResolution.Day, LocationResolution.Country,
+            100, new SmartMeterId(Guid.NewGuid()));
+
+        // When
+        var result = specification.IsSatisfiedBy(policy);
+
+        // Then
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Given_PriceIsLessThanMaxPrice_When_IsSatisfiedByIsCalled_Then_ReturnsTrue()
+    {
+        // Given
+        var specification = new PriceSpecification(100);
+        var policy = Policy.Create(new PolicyId(Guid.NewGuid()), MeasurementResolution.Day, LocationResolution.Country,
+            90, new SmartMeterId(Guid.NewGuid()));
+
+        // When
+        var result = specification.IsSatisfiedBy(policy);
+
+        // Then
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Given_PriceIsGreaterThanMaxPrice_When_IsSatisfiedByIsCalled_Then_ReturnsFalse()
+    {
+        // Given
+        var specification = new PriceSpecification(100);
+        var policy = Policy.Create(new PolicyId(Guid.NewGuid()), MeasurementResolution.Day, LocationResolution.Country,
+            110, new SmartMeterId(Guid.NewGuid()));
+
+        // When
+        var result = specification.IsSatisfiedBy(policy);
+
+        // Then
+        Assert.That(result, Is.False);
+    }
+}

--- a/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/PolicyRequestTests.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/PolicyRequestTests.cs
@@ -50,4 +50,32 @@ public class PolicyRequestTests : TestBase
         Assert.That(policyDto, Is.Not.Null);
         Assert.That(policyDto.Id, Is.EqualTo(policyIdExpected));
     }
+
+    [Test]
+    public async Task GivenPolicyRequestIdAndAccessToken_WhenCreatePolicyRequest_ThenMatchingPoliciesAreReturned()
+    {
+        // Given
+        const int policyCountExpected = 1;
+        var policyIdExpected = Guid.Parse("f4c70232-6715-4c15-966f-bf4bcef46d39");
+        var policyRequestId = Guid.Parse("58af578c-9975-4633-8dfe-ff8b70b83661");
+
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+
+        // When
+        var response = await _httpClient.GetAsync($"{BaseUrl}/{policyRequestId}/policies");
+
+        // Then
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        Assert.That(responseContent, Is.Not.Null);
+
+        var policyDtos = JsonConvert.DeserializeObject<List<PolicyDto>>(responseContent);
+        Assert.That(policyDtos, Is.Not.Null);
+        Assert.That(policyDtos, Has.Count.EqualTo(policyCountExpected));
+
+        var policyDto = policyDtos[0];
+        Assert.That(policyDto, Is.Not.Null);
+        Assert.That(policyDto.Id, Is.EqualTo(policyIdExpected));
+    }
 }

--- a/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/PolicyRequestTests.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/PolicyRequestTests.cs
@@ -2,13 +2,10 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 
-using Microsoft.EntityFrameworkCore;
-
 using Newtonsoft.Json;
 
 using SMAIAXBackend.Application.DTOs;
 using SMAIAXBackend.Domain.Model.Enums;
-using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 
 namespace SMAIAXBackend.IntegrationTests.EndToEndTests;
 
@@ -18,26 +15,19 @@ public class PolicyRequestTests : TestBase
     private const string BaseUrl = "/api/policyRequests";
 
     [Test]
-    public async Task GivenPolicyRequestCreateDtoAndAccessToken_WhenCreatePolicyRequest_ThenPolicyRequestIsCreated()
+    public async Task GivenPolicyRequestCreateDtoAndAccessToken_WhenCreatePolicyRequest_ThenMatchingPoliciesAreReturned()
     {
         // Given
+        const int policyCountExpected = 1;
+        var policyIdExpected = Guid.Parse("f4c70232-6715-4c15-966f-bf4bcef46d39");
         var policyRequestCreateDto = new PolicyRequestCreateDto(
             isAutomaticContractingEnabled: true,
             measurementResolution: MeasurementResolution.Hour,
             minHouseHoldSize: 1,
             maxHouseHoldSize: 5,
-            locations:
-            [
-                new LocationDto(
-                    streetName: "Test Street",
-                    city: "Test City",
-                    state: "Test State",
-                    country: "Test Country",
-                    continent: Continent.Africa
-                )
-            ],
-            locationResolution: LocationResolution.State,
-            maxPrice: 100);
+            locations: [],
+            locationResolution: LocationResolution.Country,
+            maxPrice: 500);
 
         var httpContent = new StringContent(JsonConvert.SerializeObject(policyRequestCreateDto), Encoding.UTF8,
             "application/json");
@@ -52,19 +42,12 @@ public class PolicyRequestTests : TestBase
         var responseContent = await response.Content.ReadAsStringAsync();
         Assert.That(responseContent, Is.Not.Null);
 
-        var returnedId = Guid.Parse(responseContent.Trim('"'));
-        var policyRequestActual = await _tenantDbContext.PolicyRequests
-            .AsNoTracking()
-            .FirstOrDefaultAsync(x => x.Id.Equals(new PolicyRequestId(returnedId)));
+        var policyDtos = JsonConvert.DeserializeObject<List<PolicyDto>>(responseContent);
+        Assert.That(policyDtos, Is.Not.Null);
+        Assert.That(policyDtos, Has.Count.EqualTo(policyCountExpected));
 
-        Assert.That(policyRequestActual, Is.Not.Null);
-        Assert.Multiple(() =>
-        {
-            Assert.That(policyRequestActual.IsAutomaticContractingEnabled, Is.EqualTo(policyRequestCreateDto.IsAutomaticContractingEnabled));
-            Assert.That(policyRequestActual.PolicyFilter.MeasurementResolution, Is.EqualTo(policyRequestCreateDto.MeasurementResolution));
-            Assert.That(policyRequestActual.PolicyFilter.MinHouseHoldSize, Is.EqualTo(policyRequestCreateDto.MinHouseHoldSize));
-            Assert.That(policyRequestActual.PolicyFilter.MaxHouseHoldSize, Is.EqualTo(policyRequestCreateDto.MaxHouseHoldSize));
-            Assert.That(policyRequestActual.PolicyFilter.Locations, Has.Count.EqualTo(policyRequestCreateDto.Locations.Count));
-        });
+        var policyDto = policyDtos[0];
+        Assert.That(policyDto, Is.Not.Null);
+        Assert.That(policyDto.Id, Is.EqualTo(policyIdExpected));
     }
 }

--- a/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/PolicyTests.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/PolicyTests.cs
@@ -38,7 +38,7 @@ public class PolicyTests : TestBase
         Assert.That(responseContent, Is.Not.Null);
 
         var returnedId = Guid.Parse(responseContent.Trim('"'));
-        var policyActual = await _tenantDbContext.Policies
+        var policyActual = await _tenant1DbContext.Policies
             .AsNoTracking()
             .FirstOrDefaultAsync(x => x.Id.Equals(new PolicyId(returnedId)));
 

--- a/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/SmartMeterTests.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/EndToEndTests/SmartMeterTests.cs
@@ -35,7 +35,7 @@ public class SmartMeterTests : TestBase
         Assert.That(locationHeader, Is.Not.Null);
 
         var id = locationHeader.Segments[^1];
-        var smartMeterActual = await _tenantDbContext.SmartMeters
+        var smartMeterActual = await _tenant1DbContext.SmartMeters
             .AsNoTracking()
             .FirstOrDefaultAsync(x =>
                 x.Id.Equals(new SmartMeterId(Guid.Parse(id))));
@@ -171,7 +171,7 @@ public class SmartMeterTests : TestBase
         var returnedId = Guid.Parse(responseContent.Trim('"'));
         Assert.That(returnedId, Is.EqualTo(smartMeterId));
 
-        var smartMeterActual = await _tenantDbContext.SmartMeters
+        var smartMeterActual = await _tenant1DbContext.SmartMeters
             .AsNoTracking()
             .FirstOrDefaultAsync(x => x.Id.Equals(new SmartMeterId(returnedId)));
         Assert.That(smartMeterActual, Is.Not.Null);
@@ -219,7 +219,7 @@ public class SmartMeterTests : TestBase
         var returnedId = Guid.Parse(responseContent.Trim('"'));
         Assert.That(returnedId, Is.EqualTo(smartMeterId));
 
-        var smartMeter = await _tenantDbContext.SmartMeters
+        var smartMeter = await _tenant1DbContext.SmartMeters
             .AsNoTracking()
             .Include(smartMeter => smartMeter.Metadata)
             .FirstOrDefaultAsync(x => x.Id.Equals(new SmartMeterId(returnedId)));
@@ -272,7 +272,7 @@ public class SmartMeterTests : TestBase
         // Then
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
 
-        var smartMeter = await _tenantDbContext.SmartMeters
+        var smartMeter = await _tenant1DbContext.SmartMeters
             .AsNoTracking()
             .Include(smartMeter => smartMeter.Metadata)
             .FirstOrDefaultAsync(x => x.Id.Equals(new SmartMeterId(smartMeterId)));

--- a/tests/SMAIAXBackend.IntegrationTests/RepositoryTests/PolicyRepositoryTests.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/RepositoryTests/PolicyRepositoryTests.cs
@@ -19,7 +19,7 @@ public class PolicyRepositoryTests : TestBase
 
         // When
         await _policyRepository.AddAsync(policyExpected);
-        var policyActual = await _tenantDbContext.Policies
+        var policyActual = await _tenant1DbContext.Policies
             .AsNoTracking()
             .FirstOrDefaultAsync(p => p.Id.Equals(policyExpected.Id));
 

--- a/tests/SMAIAXBackend.IntegrationTests/RepositoryTests/PolicyRequestRepositoryTests.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/RepositoryTests/PolicyRequestRepositoryTests.cs
@@ -21,7 +21,7 @@ public class PolicyRequestRepositoryTests : TestBase
 
         // When
         await _policyRequestRepository.AddAsync(policyRequestExpected);
-        var policyRequestActual = await _tenantDbContext.PolicyRequests
+        var policyRequestActual = await _tenant1DbContext.PolicyRequests
             .AsNoTracking()
             .FirstOrDefaultAsync(pr => pr.Id.Equals(policyRequestExpected.Id));
 

--- a/tests/SMAIAXBackend.IntegrationTests/RepositoryTests/PolicyRequestRepositoryTests.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/RepositoryTests/PolicyRequestRepositoryTests.cs
@@ -47,4 +47,28 @@ public class PolicyRequestRepositoryTests : TestBase
             Assert.That(policyRequestActual.State, Is.EqualTo(policyRequestExpected.State));
         });
     }
+
+    [Test]
+    public async Task GivenPolicyRequestId_WhenGetById_ThenExpectedPolicyRequestIsReturned()
+    {
+        // Given
+        var policyRequestId = new PolicyRequestId(Guid.Parse("58af578c-9975-4633-8dfe-ff8b70b83661"));
+
+        // When
+        var policyRequestActual = await _policyRequestRepository.GetPolicyRequestByIdAsync(policyRequestId);
+
+        // Then
+        Assert.That(policyRequestActual, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(policyRequestActual.Id, Is.EqualTo(policyRequestId));
+            Assert.That(policyRequestActual.IsAutomaticContractingEnabled, Is.False);
+            Assert.That(policyRequestActual.PolicyFilter.MeasurementResolution, Is.EqualTo(MeasurementResolution.Hour));
+            Assert.That(policyRequestActual.PolicyFilter.MinHouseHoldSize, Is.EqualTo(1));
+            Assert.That(policyRequestActual.PolicyFilter.MaxHouseHoldSize, Is.EqualTo(10));
+            Assert.That(policyRequestActual.PolicyFilter.Locations, Is.Empty);
+            Assert.That(policyRequestActual.PolicyFilter.LocationResolution, Is.EqualTo(LocationResolution.State));
+            Assert.That(policyRequestActual.PolicyFilter.MaxPrice, Is.EqualTo(500));
+        });
+    }
 }

--- a/tests/SMAIAXBackend.IntegrationTests/RepositoryTests/SmartMeterRepositoryTests.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/RepositoryTests/SmartMeterRepositoryTests.cs
@@ -16,7 +16,7 @@ public class SmartMeterRepositoryTests : TestBase
 
         // When
         await _smartMeterRepository.AddAsync(smartMeterExpected);
-        var smartMeterActual = await _tenantDbContext.SmartMeters
+        var smartMeterActual = await _tenant1DbContext.SmartMeters
             .AsNoTracking()
             .FirstOrDefaultAsync(sm => sm.Id.Equals(smartMeterExpected.Id));
 
@@ -87,7 +87,7 @@ public class SmartMeterRepositoryTests : TestBase
         await _smartMeterRepository.UpdateAsync(smartMeterExpected);
 
         // Then
-        var smartMeterActual = await _tenantDbContext.SmartMeters
+        var smartMeterActual = await _tenant1DbContext.SmartMeters
             .AsNoTracking()
             .FirstOrDefaultAsync(sm => sm.Id.Equals(smartMeterExpected.Id));
         Assert.That(smartMeterActual, Is.Not.Null);

--- a/tests/SMAIAXBackend.IntegrationTests/TestBase.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/TestBase.cs
@@ -154,6 +154,9 @@ public class TestBase
         var smartMeter1 = SmartMeter.Create(new SmartMeterId(Guid.Parse("5e9db066-1b47-46cc-bbde-0b54c30167cd")),
             "Smart Meter 1", []);
         var smartMeter2 = SmartMeter.Create(smartMeter2Id, "Smart Meter 2", [smartMeter2Metadata]);
+        var policyRequest = PolicyRequest.Create(new PolicyRequestId(Guid.Parse("58af578c-9975-4633-8dfe-ff8b70b83661")),
+            false, new PolicyFilter(MeasurementResolution.Hour, 1, 10, [],
+                LocationResolution.State, 500));
 
         // Jane Doe
         var smartMeter3Id = new SmartMeterId(Guid.Parse("f4c70232-6715-4c15-966f-bf4bcef46d39"));
@@ -180,6 +183,7 @@ public class TestBase
         await _applicationDbContext.RefreshTokens.AddAsync(refreshToken4);
         await _tenant1DbContext.SmartMeters.AddAsync(smartMeter1);
         await _tenant1DbContext.SmartMeters.AddAsync(smartMeter2);
+        await _tenant1DbContext.PolicyRequests.AddAsync(policyRequest);
         await _tenant2DbContext.SmartMeters.AddAsync(smartMeter3);
         await _tenant2DbContext.Policies.AddAsync(policy1);
         await _tenant2DbContext.Policies.AddAsync(policy2);


### PR DESCRIPTION
- **feat(specifications): implement policy specifications with tests**
  - Added `PriceSpecification` to filter policies based on maximum price.
  - Added `MeasurementResolutionSpecification` to filter policies by measurement resolution.
  - Implemented `PolicyMatchesRequestSpecification` to combine multiple criteria for matching policies with requests.
  - Moved Entity Unit Tests into Model folder and created Specifications Folder for Specification Unit Tests
  - Wrote unit tests for `PriceSpecification`, `MeasurementResolutionSpecification`, and `PolicyMatchesRequestSpecification` to validate correct behavior.
  

- **feat(policy-matching): implement matching policies based on policy request**
  - Refactored CreatePolicyRequestEndpoint to return a List of PolicyDtos
  - Refactored PolicyRequestCreateService to find matching policies and returning them.
  - Added GetAll method in TenantRepository to get all tenants
  - Added GetPoliciesByTenantAsync to get all policies of a tenant
  - Updated unit and integration tests.
  

- **refactor(policy-matching): extract matching logic into own service**
  - Created PolicyMatchingService and moved matching logic into this service
  - Created GetMatchingPoliciesEndpoint to get matching policies for an existing policy request
  - Refactored PolicyRequestCreateService to use PolicyMatchingService to get matching policies
  - Added new unit and integration tests and updated existing tests that are affected by the changes.
  