### PR TITLE
Use Hashicorp Vault to store tenant database credentials

### DIFF
--- a/SMAIAXBackend.sln
+++ b/SMAIAXBackend.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 		.editorconfig = .editorconfig
 		.github\workflows\ci.yml = .github\workflows\ci.yml
+		vault\config\entrypoint.sh = vault\config\entrypoint.sh
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SMAIAXBackend.Application.UnitTests", "tests\SMAIAXBackend.Application.UnitTests\SMAIAXBackend.Application.UnitTests.csproj", "{EEDBD571-1267-427B-B4F3-55F26BF243D3}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,12 @@
     ports:
       - "8200:8200"
     environment:
-      VAULT_ADDR: 'https://0.0.0.0:8201'
+      VAULT_ADDR: 'http://0.0.0.0:8200'
       VAULT_DEV_ROOT_TOKEN_ID: '00000000-0000-0000-0000-000000000000'
       VAULT_TOKEN: '00000000-0000-0000-0000-000000000000'
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: smaiax-db
     cap_add:
       - IPC_LOCK
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,6 @@
       VAULT_ADDR: 'http://0.0.0.0:8200'
       VAULT_DEV_ROOT_TOKEN_ID: '00000000-0000-0000-0000-000000000000'
       VAULT_TOKEN: '00000000-0000-0000-0000-000000000000'
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: smaiax-db
     cap_add:
       - IPC_LOCK
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,28 @@
     networks:
       - smaiax-frontend-network
       - smaiax-backend-network
+  
+  vault:
+    image: vault:1.13.3
+    container_name: "smaiax-vault"
+    restart: always
+    ports:
+      - "8200:8200"
+    environment:
+      VAULT_ADDR: 'https://0.0.0.0:8201'
+      VAULT_DEV_ROOT_TOKEN_ID: '00000000-0000-0000-0000-000000000000'
+      VAULT_TOKEN: '00000000-0000-0000-0000-000000000000'
+    cap_add:
+      - IPC_LOCK
+    volumes:
+      - ./vault/:/vault/
+    command:
+      - ./vault/config/entrypoint.sh
+    networks:
+      - smaiax-backend-network
+    depends_on:
+      - postgres
+
   postgres:
     image: postgres:16-bullseye
     container_name: "smaiax-backend-db"

--- a/src/SMAIAXBackend.API/ApplicationConfigurations/DatabaseExtensions.cs
+++ b/src/SMAIAXBackend.API/ApplicationConfigurations/DatabaseExtensions.cs
@@ -39,7 +39,7 @@ public static class DatabaseExtensions
             var tenantContextService = serviceProvider.GetRequiredService<ITenantContextService>();
             var tenantDbContextFactory = serviceProvider.GetRequiredService<ITenantDbContextFactory>();
             var currentTenant = tenantContextService.GetCurrentTenantAsync().GetAwaiter().GetResult();
-            var connectionString = tenantDbContextFactory.GetConnectionStringForTenant(currentTenant);
+            var connectionString = tenantDbContextFactory.GetConnectionStringForTenant(currentTenant).GetAwaiter().GetResult();
             options.UseNpgsql(connectionString);
         });
     }

--- a/src/SMAIAXBackend.API/ApplicationConfigurations/ExternalServiceExtensions.cs
+++ b/src/SMAIAXBackend.API/ApplicationConfigurations/ExternalServiceExtensions.cs
@@ -1,0 +1,14 @@
+using SMAIAXBackend.Domain.Repositories;
+using SMAIAXBackend.Infrastructure.Configurations;
+using SMAIAXBackend.Infrastructure.Repositories;
+
+namespace SMAIAXBackend.API.ApplicationConfigurations;
+
+public static class ExternalServiceExtensions
+{
+    public static void AddExternalServiceConfigurations(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<VaultConfiguration>(configuration.GetSection("Vault"));
+        services.AddSingleton<IVaultService, VaultService>();
+    }
+}

--- a/src/SMAIAXBackend.API/appsettings.Development.json
+++ b/src/SMAIAXBackend.API/appsettings.Development.json
@@ -23,7 +23,9 @@
     "Address": "http://localhost:8200",
     "Token": "00000000-0000-0000-0000-000000000000",
     "DatabaseHost": "smaiax-backend-db",
-    "DatabasePort": "5432"
+    "DatabasePort": "5432",
+    "CredentialsDefaultTimeToLive": "1h",
+    "CredentialsMaxTimeToLive": "24h"
   },
   "Logging": {
     "LogLevel": {

--- a/src/SMAIAXBackend.API/appsettings.Development.json
+++ b/src/SMAIAXBackend.API/appsettings.Development.json
@@ -19,6 +19,12 @@
     "Password": "P@ssw0rd",
     "Database": "tenant_1_db"
   },
+  "Vault": {
+    "Address": "http://localhost:8200",
+    "Token": "00000000-0000-0000-0000-000000000000",
+    "DatabaseHost": "smaiax-backend-db",
+    "DatabasePort": "5432"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/SMAIAXBackend.API/appsettings.DockerDevelopment.json
+++ b/src/SMAIAXBackend.API/appsettings.DockerDevelopment.json
@@ -19,6 +19,14 @@
     "Password": "P@ssw0rd",
     "Database": "tenant_1_db"
   },
+  "Vault": {
+    "Address": "http://smaiax-vault:8200",
+    "Token": "00000000-0000-0000-0000-000000000000",
+    "DatabaseHost": "smaiax-backend-db",
+    "DatabasePort": "5432",
+    "CredentialsDefaultTimeToLive": "1h",
+    "CredentialsMaxTimeToLive": "24h"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/SMAIAXBackend.Application/Exceptions/VaultRoleCreationException.cs
+++ b/src/SMAIAXBackend.Application/Exceptions/VaultRoleCreationException.cs
@@ -2,5 +2,5 @@ namespace SMAIAXBackend.Application.Exceptions;
 
 public class VaultRoleCreationException : Exception
 {
-    
+
 }

--- a/src/SMAIAXBackend.Application/Exceptions/VaultRoleCreationException.cs
+++ b/src/SMAIAXBackend.Application/Exceptions/VaultRoleCreationException.cs
@@ -1,0 +1,6 @@
+namespace SMAIAXBackend.Application.Exceptions;
+
+public class VaultRoleCreationException : Exception
+{
+    
+}

--- a/src/SMAIAXBackend.Domain/Model/Entities/Tenant.cs
+++ b/src/SMAIAXBackend.Domain/Model/Entities/Tenant.cs
@@ -5,14 +5,12 @@ namespace SMAIAXBackend.Domain.Model.Entities;
 public sealed class Tenant : IEquatable<Tenant>
 {
     public TenantId Id { get; } = null!;
-    // TODO: Move credentials to a secure store e.g. HashiCorp Vault
-    public string DatabaseUsername { get; }
-    public string DatabasePassword { get; }
+    public string VaultRoleName { get; }
     public string DatabaseName { get; }
 
-    public static Tenant Create(TenantId id, string databaseUsername, string databasePassword, string databaseName)
+    public static Tenant Create(TenantId id, string vaulRoleName, string databaseName)
     {
-        return new Tenant(id, databaseUsername, databasePassword, databaseName);
+        return new Tenant(id, vaulRoleName, databaseName);
     }
 
     // Needed by EF Core
@@ -20,11 +18,10 @@ public sealed class Tenant : IEquatable<Tenant>
     {
     }
 
-    private Tenant(TenantId id, string databaseUsername, string databasePassword, string databaseName)
+    private Tenant(TenantId id, string vaultRoleName, string databaseName)
     {
         Id = id;
-        DatabaseUsername = databaseUsername;
-        DatabasePassword = databasePassword;
+        VaultRoleName = vaultRoleName;
         DatabaseName = databaseName;
     }
 

--- a/src/SMAIAXBackend.Domain/Repositories/ITenantRepository.cs
+++ b/src/SMAIAXBackend.Domain/Repositories/ITenantRepository.cs
@@ -9,5 +9,5 @@ public interface ITenantRepository
     Task AddAsync(Tenant tenant);
     Task DeleteAsync(Tenant tenant);
     Task<Tenant?> GetByIdAsync(TenantId tenantId);
-    Task CreateDatabaseForTenantAsync(string databaseName, string databaseUserName, string databasePassword);
+    Task CreateDatabaseForTenantAsync(string databaseName);
 }

--- a/src/SMAIAXBackend.Domain/Repositories/IVaultService.cs
+++ b/src/SMAIAXBackend.Domain/Repositories/IVaultService.cs
@@ -1,0 +1,6 @@
+namespace SMAIAXBackend.Domain.Repositories;
+
+public interface IVaultService
+{
+    Task CreateDatabaseRoleAsync(string roleName, string databaseName);
+}

--- a/src/SMAIAXBackend.Domain/Repositories/IVaultService.cs
+++ b/src/SMAIAXBackend.Domain/Repositories/IVaultService.cs
@@ -3,4 +3,5 @@ namespace SMAIAXBackend.Domain.Repositories;
 public interface IVaultService
 {
     Task CreateDatabaseRoleAsync(string roleName, string databaseName);
+    Task<(string Username, string Password)> GetDatabaseCredentialsAsync(string roleName);
 }

--- a/src/SMAIAXBackend.Infrastructure/Configurations/VaultConfiguration.cs
+++ b/src/SMAIAXBackend.Infrastructure/Configurations/VaultConfiguration.cs
@@ -7,6 +7,6 @@ public class VaultConfiguration
     // We need to specify the database host here because when running the application locally
     // the database host for the application is localhost.
     // Vault is running in a container and needs the container name of the database host.
-    public required string DatabaseHost { get; init; } 
+    public required string DatabaseHost { get; init; }
     public required int DatabasePort { get; init; }
 }

--- a/src/SMAIAXBackend.Infrastructure/Configurations/VaultConfiguration.cs
+++ b/src/SMAIAXBackend.Infrastructure/Configurations/VaultConfiguration.cs
@@ -9,4 +9,6 @@ public class VaultConfiguration
     // Vault is running in a container and needs the container name of the database host.
     public required string DatabaseHost { get; init; }
     public required int DatabasePort { get; init; }
+    public required string CredentialsDefaultTimeToLive { get; init; }
+    public required string CredentialsMaximumTimeToLive { get; init; }
 }

--- a/src/SMAIAXBackend.Infrastructure/Configurations/VaultConfiguration.cs
+++ b/src/SMAIAXBackend.Infrastructure/Configurations/VaultConfiguration.cs
@@ -1,0 +1,12 @@
+namespace SMAIAXBackend.Infrastructure.Configurations;
+
+public class VaultConfiguration
+{
+    public required string Address { get; init; }
+    public required string Token { get; init; }
+    // We need to specify the database host here because when running the application locally
+    // the database host for the application is localhost.
+    // Vault is running in a container and needs the container name of the database host.
+    public required string DatabaseHost { get; init; } 
+    public required int DatabasePort { get; init; }
+}

--- a/src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs
+++ b/src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs
@@ -62,7 +62,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         var passwordHash = hasher.HashPassword(testUser, password!);
         testUser.PasswordHash = passwordHash;
 
-        var tenant = Tenant.Create(new TenantId(Guid.NewGuid()), userName, password!, tenantDatabase!);
+        var tenant = Tenant.Create(new TenantId(Guid.NewGuid()), "tenant_1_role", tenantDatabase!);
         var domainUser = User.Create(userId, new Name("John", "Doe"), userName, email, tenant.Id);
 
         await Users.AddAsync(testUser);

--- a/src/SMAIAXBackend.Infrastructure/DbContexts/ITenantDbContextFactory.cs
+++ b/src/SMAIAXBackend.Infrastructure/DbContexts/ITenantDbContextFactory.cs
@@ -5,5 +5,5 @@ namespace SMAIAXBackend.Infrastructure.DbContexts;
 public interface ITenantDbContextFactory
 {
     TenantDbContext CreateDbContext(string databaseName, string databaseUserName, string databasePassword);
-    string GetConnectionStringForTenant(Tenant tenant);
+    Task<string> GetConnectionStringForTenant(Tenant tenant);
 }

--- a/src/SMAIAXBackend.Infrastructure/DbContexts/TenantDbContextFactory.cs
+++ b/src/SMAIAXBackend.Infrastructure/DbContexts/TenantDbContextFactory.cs
@@ -30,7 +30,7 @@ public class TenantDbContextFactory(IOptions<DatabaseConfiguration> databaseConf
     public async Task<string> GetConnectionStringForTenant(Tenant tenant)
     {
         var credentials = await vaultService.GetDatabaseCredentialsAsync(tenant.VaultRoleName);
-       
+
         var connectionStringBuilder = new NpgsqlConnectionStringBuilder
         {
             Host = databaseConfigOptions.Value.Host,

--- a/src/SMAIAXBackend.Infrastructure/DbContexts/TenantDbContextFactory.cs
+++ b/src/SMAIAXBackend.Infrastructure/DbContexts/TenantDbContextFactory.cs
@@ -28,12 +28,13 @@ public class TenantDbContextFactory(IOptions<DatabaseConfiguration> databaseConf
 
     public string GetConnectionStringForTenant(Tenant tenant)
     {
+        // TODO: Credentials are retrieved from vault
         var connectionStringBuilder = new NpgsqlConnectionStringBuilder
         {
             Host = databaseConfigOptions.Value.Host,
             Port = databaseConfigOptions.Value.Port,
-            Username = tenant.DatabaseUsername,
-            Password = tenant.DatabasePassword,
+            Username = "tenant.DatabaseUsername",
+            Password = "tenant.DatabasePassword",
             Database = tenant.DatabaseName
         };
 

--- a/src/SMAIAXBackend.Infrastructure/DbContexts/TenantDbContextFactory.cs
+++ b/src/SMAIAXBackend.Infrastructure/DbContexts/TenantDbContextFactory.cs
@@ -4,11 +4,12 @@ using Microsoft.Extensions.Options;
 using Npgsql;
 
 using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Repositories;
 using SMAIAXBackend.Infrastructure.Configurations;
 
 namespace SMAIAXBackend.Infrastructure.DbContexts;
 
-public class TenantDbContextFactory(IOptions<DatabaseConfiguration> databaseConfigOptions) : ITenantDbContextFactory
+public class TenantDbContextFactory(IOptions<DatabaseConfiguration> databaseConfigOptions, IVaultService vaultService) : ITenantDbContextFactory
 {
     public TenantDbContext CreateDbContext(string databaseName, string databaseUserName, string databasePassword)
     {
@@ -26,15 +27,16 @@ public class TenantDbContextFactory(IOptions<DatabaseConfiguration> databaseConf
         return new TenantDbContext(optionsBuilder.Options);
     }
 
-    public string GetConnectionStringForTenant(Tenant tenant)
+    public async Task<string> GetConnectionStringForTenant(Tenant tenant)
     {
-        // TODO: Credentials are retrieved from vault
+        var credentials = await vaultService.GetDatabaseCredentialsAsync(tenant.VaultRoleName);
+       
         var connectionStringBuilder = new NpgsqlConnectionStringBuilder
         {
             Host = databaseConfigOptions.Value.Host,
             Port = databaseConfigOptions.Value.Port,
-            Username = "tenant.DatabaseUsername",
-            Password = "tenant.DatabasePassword",
+            Username = credentials.Username,
+            Password = credentials.Password,
             Database = tenant.DatabaseName
         };
 

--- a/src/SMAIAXBackend.Infrastructure/EntityConfigurations/TenantConfiguration.cs
+++ b/src/SMAIAXBackend.Infrastructure/EntityConfigurations/TenantConfiguration.cs
@@ -19,10 +19,7 @@ public class TenantConfiguration : IEntityTypeConfiguration<Tenant>
                 v => new TenantId(v))
             .IsRequired();
 
-        builder.Property(t => t.DatabaseUsername)
-            .IsRequired();
-
-        builder.Property(t => t.DatabasePassword)
+        builder.Property(t => t.VaultRoleName)
             .IsRequired();
 
         builder.Property(t => t.DatabaseName)

--- a/src/SMAIAXBackend.Infrastructure/Repositories/TenantRepository.cs
+++ b/src/SMAIAXBackend.Infrastructure/Repositories/TenantRepository.cs
@@ -36,74 +36,18 @@ public class TenantRepository(
         return await applicationDbContext.Tenants.FindAsync(tenantId);
     }
 
-    public async Task CreateDatabaseForTenantAsync(
-        string databaseName,
-        string databaseUserName,
-        string databasePassword)
+    public async Task CreateDatabaseForTenantAsync(string databaseName)
     {
-        await OpenDatabaseConnectionAsync(applicationDbContext);
-        await CreateDatabaseAsync(databaseName);
-        await CreateUserAsync(databaseUserName, databasePassword);
-        await GrantDatabasePrivilegesAsync(databaseName, databaseUserName);
-        await CloseDatabaseConnectionAsync(applicationDbContext);
+        await applicationDbContext.Database.OpenConnectionAsync();
+        
+        await using var createDbCommand = applicationDbContext.Database.GetDbConnection().CreateCommand();
+        createDbCommand.CommandText = $"CREATE DATABASE {databaseName};";
+        await createDbCommand.ExecuteNonQueryAsync();
+        
+        await applicationDbContext.Database.CloseConnectionAsync();
 
         var tenantDbContext = tenantDbContextFactory.CreateDbContext(databaseName,
             databaseConfigOptions.Value.SuperUsername, databaseConfigOptions.Value.SuperUserPassword);
         await tenantDbContext.Database.MigrateAsync();
-
-        await OpenDatabaseConnectionAsync(tenantDbContext);
-        await SetSchemaPrivilegesAsync(tenantDbContext, databaseUserName);
-        await CloseDatabaseConnectionAsync(tenantDbContext);
-    }
-
-    private static async Task OpenDatabaseConnectionAsync(DbContext dbContext)
-    {
-        await dbContext.Database.OpenConnectionAsync();
-    }
-
-    private async Task CreateDatabaseAsync(string databaseName)
-    {
-        await using var createDbCommand = applicationDbContext.Database.GetDbConnection().CreateCommand();
-        createDbCommand.CommandText = $"CREATE DATABASE {databaseName};";
-        await createDbCommand.ExecuteNonQueryAsync();
-    }
-
-    private async Task CreateUserAsync(string databaseUserName, string databasePassword)
-    {
-        await using var createUserCommand = applicationDbContext.Database.GetDbConnection().CreateCommand();
-        createUserCommand.CommandText = $"CREATE USER {databaseUserName} WITH PASSWORD '{databasePassword}';";
-        await createUserCommand.ExecuteNonQueryAsync();
-    }
-
-    private async Task GrantDatabasePrivilegesAsync(string databaseName, string databaseUserName)
-    {
-        await using var grantPrivilegesCommand = applicationDbContext.Database.GetDbConnection().CreateCommand();
-        grantPrivilegesCommand.CommandText = $"GRANT CONNECT ON DATABASE {databaseName} TO {databaseUserName};";
-        await grantPrivilegesCommand.ExecuteNonQueryAsync();
-    }
-
-    private static async Task CloseDatabaseConnectionAsync(DbContext dbContext)
-    {
-        await dbContext.Database.CloseConnectionAsync();
-    }
-
-    private static async Task SetSchemaPrivilegesAsync(DbContext tenantDbContext, string databaseUserName)
-    {
-        await using var setSchemaPrivilegesCommand = tenantDbContext.Database.GetDbConnection().CreateCommand();
-
-        setSchemaPrivilegesCommand.CommandText = $@"
-    GRANT USAGE ON SCHEMA domain TO {databaseUserName};
-    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA domain TO {databaseUserName};
-    ";
-        await setSchemaPrivilegesCommand.ExecuteNonQueryAsync();
-
-        setSchemaPrivilegesCommand.CommandText = $@"
-    ALTER DEFAULT PRIVILEGES IN SCHEMA domain 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO {databaseUserName};
-    ";
-        await setSchemaPrivilegesCommand.ExecuteNonQueryAsync();
-
-        setSchemaPrivilegesCommand.CommandText = $"REVOKE ALL ON SCHEMA public FROM {databaseUserName};";
-        await setSchemaPrivilegesCommand.ExecuteNonQueryAsync();
     }
 }

--- a/src/SMAIAXBackend.Infrastructure/Repositories/TenantRepository.cs
+++ b/src/SMAIAXBackend.Infrastructure/Repositories/TenantRepository.cs
@@ -40,7 +40,7 @@ public class TenantRepository(
     {
         return await applicationDbContext.Tenants.ToListAsync();
     }
-    
+
     public async Task CreateDatabaseForTenantAsync(string databaseName)
     {
         await applicationDbContext.Database.OpenConnectionAsync();

--- a/src/SMAIAXBackend.Infrastructure/Repositories/TenantRepository.cs
+++ b/src/SMAIAXBackend.Infrastructure/Repositories/TenantRepository.cs
@@ -39,11 +39,11 @@ public class TenantRepository(
     public async Task CreateDatabaseForTenantAsync(string databaseName)
     {
         await applicationDbContext.Database.OpenConnectionAsync();
-        
+
         await using var createDbCommand = applicationDbContext.Database.GetDbConnection().CreateCommand();
         createDbCommand.CommandText = $"CREATE DATABASE {databaseName};";
         await createDbCommand.ExecuteNonQueryAsync();
-        
+
         await applicationDbContext.Database.CloseConnectionAsync();
 
         var tenantDbContext = tenantDbContextFactory.CreateDbContext(databaseName,

--- a/src/SMAIAXBackend.Infrastructure/Repositories/VaultService.cs
+++ b/src/SMAIAXBackend.Infrastructure/Repositories/VaultService.cs
@@ -63,10 +63,9 @@ public class VaultService : IVaultService
 
         await _vaultClient.V1.Secrets.Database.CreateRoleAsync(roleName, role);
     }
-    
+
     public async Task<(string Username, string Password)> GetDatabaseCredentialsAsync(string roleName)
     {
-        // TODO: Implement caching the credentials until the ttl passed so that it does not create a new database user each time
         try
         {
             var secrets = await _vaultClient.V1.Secrets.Database.GetCredentialsAsync(roleName);

--- a/src/SMAIAXBackend.Infrastructure/Repositories/VaultService.cs
+++ b/src/SMAIAXBackend.Infrastructure/Repositories/VaultService.cs
@@ -18,6 +18,8 @@ public class VaultService : IVaultService
     private readonly int _databasePort;
     private readonly string _databaseSuperUsername;
     private readonly string _databaseSuperUserPassword;
+    private readonly string _credentialsDefaultTimeToLive;
+    private readonly string _credentialsMaximumTimeToLive;
 
     public VaultService(
         IOptions<VaultConfiguration> vaultConfigOptions,
@@ -27,6 +29,8 @@ public class VaultService : IVaultService
         _vaultClient = new VaultClient(new VaultClientSettings(vaultConfigOptions.Value.Address, authMethod));
         _databaseHost = vaultConfigOptions.Value.DatabaseHost;
         _databasePort = vaultConfigOptions.Value.DatabasePort;
+        _credentialsDefaultTimeToLive = vaultConfigOptions.Value.CredentialsDefaultTimeToLive;
+        _credentialsMaximumTimeToLive = vaultConfigOptions.Value.CredentialsMaximumTimeToLive;
         _databaseSuperUsername = databaseConfigOptions.Value.SuperUsername;
         _databaseSuperUserPassword = databaseConfigOptions.Value.SuperUserPassword;
     }
@@ -48,8 +52,8 @@ public class VaultService : IVaultService
         var role = new Role
         {
             DatabaseProviderType = new DatabaseProviderType(databaseName),
-            DefaultTimeToLive = "1h",
-            MaximumTimeToLive = "24h",
+            DefaultTimeToLive = _credentialsDefaultTimeToLive,
+            MaximumTimeToLive = _credentialsMaximumTimeToLive,
             CreationStatements =
             [
                 "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';",

--- a/src/SMAIAXBackend.Infrastructure/Repositories/VaultService.cs
+++ b/src/SMAIAXBackend.Infrastructure/Repositories/VaultService.cs
@@ -63,7 +63,7 @@ public class VaultService : IVaultService
 
         await _vaultClient.V1.Secrets.Database.CreateRoleAsync(roleName, role);
     }
-
+    
     public async Task<(string Username, string Password)> GetDatabaseCredentialsAsync(string roleName)
     {
         // TODO: Implement caching the credentials until the ttl passed so that it does not create a new database user each time

--- a/src/SMAIAXBackend.Infrastructure/Repositories/VaultService.cs
+++ b/src/SMAIAXBackend.Infrastructure/Repositories/VaultService.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Options;
+
+using SMAIAXBackend.Domain.Repositories;
+using SMAIAXBackend.Infrastructure.Configurations;
+
+using VaultSharp;
+using VaultSharp.V1.AuthMethods.Token;
+using VaultSharp.V1.SecretsEngines.ActiveDirectory.Models;
+using VaultSharp.V1.SecretsEngines.Database;
+using VaultSharp.V1.SecretsEngines.Database.Models.PostgreSQL;
+
+namespace SMAIAXBackend.Infrastructure.Repositories;
+
+public class VaultService : IVaultService
+{
+    private readonly IVaultClient _vaultClient;
+    private readonly string _databaseHost;
+    private readonly int _databasePort;
+    private readonly string _databaseUsername;
+    private readonly string _databasePassword;
+
+    public VaultService(IOptions<VaultConfiguration> vaultConfigOptions, IOptions<DatabaseConfiguration> databaseConfigOptions)
+    {
+        var authMethod = new TokenAuthMethodInfo(vaultConfigOptions.Value.Token);
+        _vaultClient = new VaultClient(new VaultClientSettings(vaultConfigOptions.Value.Address, authMethod));
+        _databaseHost = vaultConfigOptions.Value.DatabaseHost;
+        _databasePort = vaultConfigOptions.Value.DatabasePort;
+        _databaseUsername = databaseConfigOptions.Value.SuperUsername;
+        _databasePassword = databaseConfigOptions.Value.SuperUserPassword;
+    }
+    
+    public async Task CreateDatabaseRoleAsync(string roleName, string databaseName)
+    {
+        var databaseConnectionConfig = new PostgreSQLConnectionConfigModel
+        {
+            UsernameTemplate = "",
+            AllowedRoles = [ roleName ],
+            ConnectionUrl = $"postgresql://{{{{username}}}}:{{{{password}}}}@{_databaseHost}:{_databasePort}/{databaseName}",
+            Username = _databaseUsername,
+            Password = _databasePassword
+        };
+        
+        await _vaultClient.V1.Secrets.Database.ConfigureConnectionAsync(databaseName, databaseConnectionConfig);
+        
+        var role = new Role
+        {
+            DatabaseProviderType = new DatabaseProviderType(databaseName),
+            DefaultTimeToLive = "1h",
+            MaximumTimeToLive = "24h",
+            CreationStatements =
+            [
+                "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';",
+                $"GRANT CONNECT ON DATABASE {databaseName} TO \"{{{{name}}}}\";",
+                "GRANT USAGE ON SCHEMA domain TO \"{{name}}\";",
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA domain TO \"{{name}}\";",
+                "ALTER DEFAULT PRIVILEGES IN SCHEMA domain GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO \"{{name}}\";",
+                "REVOKE ALL ON SCHEMA public FROM \"{{name}}\";"
+            ]
+        };
+
+        await _vaultClient.V1.Secrets.Database.CreateRoleAsync(roleName, role);
+    }
+}

--- a/src/SMAIAXBackend.Infrastructure/SMAIAXBackend.Infrastructure.csproj
+++ b/src/SMAIAXBackend.Infrastructure/SMAIAXBackend.Infrastructure.csproj
@@ -19,6 +19,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
       <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.0" />
+      <PackageReference Include="VaultSharp" Version="1.17.5.1" />
     </ItemGroup>
     
     <ItemGroup>

--- a/tests/SMAIAXBackend.Application.UnitTests/AuthenticationServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/AuthenticationServiceTests.cs
@@ -41,7 +41,7 @@ public class AuthenticationServiceTests
         _vaultServiceMock = new Mock<IVaultService>();
         _loggerMock = new Mock<ILogger<AuthenticationService>>();
         _authenticationService = new AuthenticationService(_tenantRepositoryMock.Object, _userRepositoryMock.Object,
-            _tokenRepositoryMock.Object, _userManagerMock.Object, _transactionManagerMock.Object, 
+            _tokenRepositoryMock.Object, _userManagerMock.Object, _transactionManagerMock.Object,
             _vaultServiceMock.Object, _loggerMock.Object);
     }
 

--- a/tests/SMAIAXBackend.Application.UnitTests/AuthenticationServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/AuthenticationServiceTests.cs
@@ -21,6 +21,7 @@ public class AuthenticationServiceTests
     private Mock<ITokenRepository> _tokenRepositoryMock;
     private Mock<UserManager<IdentityUser>> _userManagerMock;
     private Mock<ITransactionManager> _transactionManagerMock;
+    private Mock<IVaultService> _vaultServiceMock;
     private Mock<ILogger<AuthenticationService>> _loggerMock;
     private AuthenticationService _authenticationService;
 
@@ -37,10 +38,11 @@ public class AuthenticationServiceTests
         _transactionManagerMock
             .Setup(mgr => mgr.ReadCommittedTransactionScope(It.IsAny<Func<Task>>()))
             .Returns((Func<Task> transactionalOperation) => transactionalOperation());
+        _vaultServiceMock = new Mock<IVaultService>();
         _loggerMock = new Mock<ILogger<AuthenticationService>>();
         _authenticationService = new AuthenticationService(_tenantRepositoryMock.Object, _userRepositoryMock.Object,
-            _tokenRepositoryMock.Object,
-            _userManagerMock.Object, _transactionManagerMock.Object, _loggerMock.Object);
+            _tokenRepositoryMock.Object, _userManagerMock.Object, _transactionManagerMock.Object, 
+            _vaultServiceMock.Object, _loggerMock.Object);
     }
 
     [Test]

--- a/tests/SMAIAXBackend.Application.UnitTests/PolicyMatchingServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/PolicyMatchingServiceTests.cs
@@ -48,35 +48,30 @@ public class PolicyMatchingServiceTests
         var policyRequest = PolicyRequest.Create(policyRequestId, false, policyFilter);
         var tenants = new List<Tenant>
         {
-            Tenant.Create(
-                id: new TenantId(Guid.NewGuid()),
-                databaseUsername: "test",
-                databasePassword: "test",
-                databaseName: "test"
+            Tenant.Create(new TenantId(Guid.NewGuid()), "test", "test"
             ),
             Tenant.Create(
-                id: new TenantId(Guid.NewGuid()),
-                databaseUsername: "test2",
-                databasePassword: "test2",
-                databaseName: "test2"
+                new TenantId(Guid.NewGuid()),
+                "test2",
+                "test2"
             )
         };
 
         var policies = new List<Policy>
         {
             Policy.Create(
-                id: new PolicyId(Guid.NewGuid()),
-                measurementResolution: MeasurementResolution.Hour,
-                locationResolution: LocationResolution.State,
-                price: 50,
-                smartMeterId: new SmartMeterId(Guid.NewGuid())
+                new PolicyId(Guid.NewGuid()),
+                MeasurementResolution.Hour,
+                LocationResolution.State,
+                50,
+                new SmartMeterId(Guid.NewGuid())
             ),
             Policy.Create(
-                id: new PolicyId(Guid.NewGuid()),
-                measurementResolution: MeasurementResolution.Hour,
-                locationResolution: LocationResolution.State,
-                price: 150,
-                smartMeterId: new SmartMeterId(Guid.NewGuid())
+                new PolicyId(Guid.NewGuid()),
+                MeasurementResolution.Hour,
+                LocationResolution.State,
+                150,
+                new SmartMeterId(Guid.NewGuid())
             )
         };
 

--- a/tests/SMAIAXBackend.Application.UnitTests/TenantContextServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/TenantContextServiceTests.cs
@@ -44,7 +44,7 @@ public class TenantContextServiceTests
         var tenantId = Guid.NewGuid();
         var user = User.Create(new UserId(userId), new Name("John", "Doe"), "johndoe", "john.doe@example.com",
             new TenantId(tenantId));
-        var tenant = Tenant.Create(new TenantId(tenantId), "test","test");
+        var tenant = Tenant.Create(new TenantId(tenantId), "test", "test");
 
         _httpContextAccessorMock.Setup(httpContextAccessor => httpContextAccessor.HttpContext!.Items["UserId"])
             .Returns(userId.ToString());

--- a/tests/SMAIAXBackend.Application.UnitTests/TenantContextServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/TenantContextServiceTests.cs
@@ -44,7 +44,7 @@ public class TenantContextServiceTests
         var tenantId = Guid.NewGuid();
         var user = User.Create(new UserId(userId), new Name("John", "Doe"), "johndoe", "john.doe@example.com",
             new TenantId(tenantId));
-        var tenant = Tenant.Create(new TenantId(tenantId), "test", "test", "test");
+        var tenant = Tenant.Create(new TenantId(tenantId), "test","test");
 
         _httpContextAccessorMock.Setup(httpContextAccessor => httpContextAccessor.HttpContext!.Items["UserId"])
             .Returns(userId.ToString());

--- a/tests/SMAIAXBackend.IntegrationTests/IntegrationTestSetup.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/IntegrationTestSetup.cs
@@ -1,4 +1,9 @@
+using System.Net;
+
 using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -13,7 +18,9 @@ namespace SMAIAXBackend.IntegrationTests;
 [SetUpFixture]
 internal static class IntegrationTestSetup
 {
+    private static INetwork _testNetwork = null!;
     private static PostgreSqlContainer _postgresContainer = null!;
+    private static IContainer _vaultContainer = null!;
     private static WebAppFactory _webAppFactory = null!;
     public static ApplicationDbContext ApplicationDbContext { get; private set; } = null!;
     public static TenantDbContext TenantDbContext { get; private set; } = null!;
@@ -22,28 +29,57 @@ internal static class IntegrationTestSetup
     public static IPolicyRequestRepository PolicyRequestRepository { get; private set; } = null!;
     public static IUserRepository UserRepository { get; private set; } = null!;
     public static ITenantRepository TenantRepository { get; private set; } = null!;
+    public static IVaultService VaultService { get; private set; } = null!;
     public static HttpClient HttpClient { get; private set; } = null!;
     public static string AccessToken { get; private set; } = null!;
 
     [OneTimeSetUp]
     public static async Task OneTimeSetup()
     {
+        const string networkName = "shared-test-network";
+        _testNetwork = new NetworkBuilder()
+            .WithName(networkName)
+            .Build();
+
+        await _testNetwork.CreateAsync();
+
+        const string postgresContainerName = "postgres-test";
         const int postgresPort = 5432;
         const string superUserName = "user";
         const string superUserPassword = "password";
+        const string databaseName = "smaiax-db";
         _postgresContainer = new PostgreSqlBuilder()
             .WithImage("postgres:16-bullseye")
+            .WithName(postgresContainerName)
             .WithUsername(superUserName)
             .WithPassword(superUserPassword)
-            .WithDatabase("smaiax-db")
+            .WithDatabase(databaseName)
             .WithPortBinding(postgresPort, true)
+            .WithNetwork(_testNetwork)
             .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(postgresPort))
             .Build();
 
         await _postgresContainer.StartAsync();
 
+        const int vaultPort = 8200;
+        _vaultContainer = new ContainerBuilder()
+            .WithImage("vault:1.13.3")
+            .WithPortBinding(vaultPort, true)
+            .WithEnvironment("VAULT_ADDR", "http://0.0.0.0:8200")
+            .WithEnvironment("VAULT_DEV_ROOT_TOKEN_ID", "00000000-0000-0000-0000-000000000000")
+            .WithEnvironment("VAULT_TOKEN", "00000000-0000-0000-0000-000000000000")
+            .WithBindMount(Path.GetFullPath("../../../../../vault/"), "/vault/")
+            .WithCommand("./vault/config/entrypoint.sh")
+            .WithNetwork(_testNetwork)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilFileExists("/tmp/healthy", FileSystem.Container))
+            .Build();
+
+        await _vaultContainer.StartAsync();
+
         var postgresMappedPublicPort = _postgresContainer.GetMappedPublicPort(postgresPort);
-        _webAppFactory = new WebAppFactory(postgresMappedPublicPort);
+        var vaultMappedPublicPort = _vaultContainer.GetMappedPublicPort(vaultPort);
+        _webAppFactory = new WebAppFactory(postgresMappedPublicPort, postgresPort, postgresContainerName,
+            vaultMappedPublicPort);
 
         HttpClient = _webAppFactory.CreateClient();
 
@@ -52,6 +88,7 @@ internal static class IntegrationTestSetup
         TenantDbContext = tenantDbContextFactory.CreateDbContext("tenant_1_db", superUserName, superUserPassword);
         TenantRepository = _webAppFactory.Services.GetRequiredService<ITenantRepository>();
         UserRepository = _webAppFactory.Services.GetRequiredService<IUserRepository>();
+        VaultService = _webAppFactory.Services.GetRequiredService<IVaultService>();
 
         // Repositories that are using the TenantDatabase need to be instantiated because
         // They are injected with a connection string that is created based on the http request
@@ -67,8 +104,12 @@ internal static class IntegrationTestSetup
     [OneTimeTearDown]
     public static async Task OneTimeTearDown()
     {
+        await _vaultContainer.StopAsync();
+        await _vaultContainer.DisposeAsync();
         await _postgresContainer.StopAsync();
         await _postgresContainer.DisposeAsync();
+        await _testNetwork.DeleteAsync();
+        await _testNetwork.DisposeAsync();
         HttpClient.Dispose();
         await _webAppFactory.DisposeAsync();
     }

--- a/tests/SMAIAXBackend.IntegrationTests/TestBase.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/TestBase.cs
@@ -32,6 +32,7 @@ public class TestBase
         IntegrationTestSetup.Tenant1DbContext.ChangeTracker.Clear();
         IntegrationTestSetup.Tenant2DbContext.ChangeTracker.Clear();
         await IntegrationTestSetup.VaultService.CreateDatabaseRoleAsync("tenant_1_role", "tenant_1_db");
+        await IntegrationTestSetup.VaultService.CreateDatabaseRoleAsync("tenant_2_role", "tenant_2_db");
     }
 
     [TearDown]

--- a/tests/SMAIAXBackend.IntegrationTests/TestBase.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/TestBase.cs
@@ -83,9 +83,9 @@ public class TestBase
         };
         var janeDoePasswordHash = hasher.HashPassword(janeDoeTestUser, janeDoePassword);
         janeDoeTestUser.PasswordHash = janeDoePasswordHash;
-        
+
         var janeDoeTenantId = new TenantId(Guid.Parse("e4c70232-6715-4c15-966f-bf4bcef46d40"));
-        var janeDoeTenant = Tenant.Create(janeDoeTenantId, "tenant_2_role","tenant_2_db");
+        var janeDoeTenant = Tenant.Create(janeDoeTenantId, "tenant_2_role", "tenant_2_db");
         var janeDoeDomainUser = User.Create(janeDoeUserId, new Name("Jane", "Doe"), janeDoeUserName, janeDoeEmail, janeDoeTenantId);
 
         // Valid refresh token

--- a/tests/SMAIAXBackend.IntegrationTests/WebAppFactory.cs
+++ b/tests/SMAIAXBackend.IntegrationTests/WebAppFactory.cs
@@ -4,7 +4,8 @@ using Microsoft.Extensions.Configuration;
 
 namespace SMAIAXBackend.IntegrationTests;
 
-public class WebAppFactory(int postgresMappedPublicPort) : WebApplicationFactory<Program>
+public class WebAppFactory(int postgresMappedPublicPort, int postgresInternalPort, string postgresContainerName, int vaultMappedPublicPort)
+    : WebApplicationFactory<Program>
 {
     private readonly Dictionary<string, string> _testAppSettings = new()
     {
@@ -17,7 +18,11 @@ public class WebAppFactory(int postgresMappedPublicPort) : WebApplicationFactory
         ["JwtConfiguration:Issuer"] = "SMAIAX",
         ["JwtConfiguration:Audience"] = "SomeAudience",
         ["JwtConfiguration:AccessTokenExpirationMinutes"] = "60",
-        ["JwtConfiguration:RefreshTokenExpirationMinutes"] = "10080"
+        ["JwtConfiguration:RefreshTokenExpirationMinutes"] = "10080",
+        ["Vault:Address"] = $"http://localhost:{vaultMappedPublicPort}",
+        ["Vault:Token"] = "00000000-0000-0000-0000-000000000000",
+        ["Vault:DatabaseHost"] = postgresContainerName,
+        ["Vault:DatabasePort"] = $"{postgresInternalPort}"
     };
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/vault/config/entrypoint.sh
+++ b/vault/config/entrypoint.sh
@@ -8,13 +8,6 @@ sleep 5s
 
 vault secrets enable database
 
-vault write database/config/postgresql \
-     plugin_name=postgresql-database-plugin \
-     connection_url="postgresql://{{username}}:{{password}}@smaiax-backend-db/${POSTGRES_DB}?sslmode=disable" \
-     allowed_roles=readonly \
-     username="${POSTGRES_USER}" \
-     password="${POSTGRES_PASSWORD}"
-
 # This container is now healthy
 touch /tmp/healthy
 

--- a/vault/config/entrypoint.sh
+++ b/vault/config/entrypoint.sh
@@ -6,16 +6,14 @@ set -e
 vault server -dev -dev-listen-address="0.0.0.0:8200" &
 sleep 5s
 
-export VAULT_ADDR='http://0.0.0.0:8200'
-
 vault secrets enable database
 
 vault write database/config/postgresql \
      plugin_name=postgresql-database-plugin \
-     connection_url="postgresql://{{username}}:{{password}}@smaiax-backend-db/smaiax-db?sslmode=disable" \
+     connection_url="postgresql://{{username}}:{{password}}@smaiax-backend-db/${POSTGRES_DB}?sslmode=disable" \
      allowed_roles=readonly \
-     username="user" \
-     password="password"
+     username="${POSTGRES_USER}" \
+     password="${POSTGRES_PASSWORD}"
 
 # This container is now healthy
 touch /tmp/healthy

--- a/vault/config/entrypoint.sh
+++ b/vault/config/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+# Start Vault server in dev mode in the background
+vault server -dev -dev-listen-address="0.0.0.0:8200" &
+sleep 5s
+
+export VAULT_ADDR='http://0.0.0.0:8200'
+
+vault secrets enable database
+
+vault write database/config/postgresql \
+     plugin_name=postgresql-database-plugin \
+     connection_url="postgresql://{{username}}:{{password}}@smaiax-backend-db/smaiax-db?sslmode=disable" \
+     allowed_roles=readonly \
+     username="user" \
+     password="password"
+
+# This container is now healthy
+touch /tmp/healthy
+
+# Keep container alive
+tail -f /dev/null & trap 'kill %1' TERM ; wait


### PR DESCRIPTION
- **feat(vault): add secrets database engine and connection setup on startup**
  - Integrated HashiCorp Vault into the Docker Compose setup.
  - Added a script to configure the secrets database engine.
  - Configured automatic setup of the database connection during startup.
  

- **feat(vault): use environment variables for dynamic database configuration**
  - Updated `entrypoint.sh` to use environment variables for PostgreSQL user, password, and database.
  - Simplified connection string by dynamically referencing `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`.
  

- **feat(vault): dynamically create tenant roles with database permissions**
  - Implemented creating database connection to tenant db for vault
  - Implemented Vault role creation to support dynamic tenant roles based on registration.
  - Removed saving database credentials in Tenant
  

- **refactor(database): retrieve database credentials from Vault**
  - Updated TenantDbContextFactory to fetch database credentials dynamically from VaultService.
  - Implemented method in VaultService to retrieve credentials using tenant-specific roles.
  

- **test(app): update tests to work with recent changes**
  - Updated unit tests for Register method
  - Added vault container to integration test setup
  

- **refactor(auth): refactor register method to separate concerns and improve error handling**
  - Added helper methods (`CreateTenantDatabaseAsync`, `CreateVaultRoleAsync`, `CleanupFailedRegistration`) to handle specific tasks separately.
  - Formatted code
  