### PR TITLE
Edit metadata

### DIFF
--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/AddMetadataEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/AddMetadataEndpoint.cs
@@ -1,5 +1,3 @@
-using System.Security.Claims;
-
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -13,8 +11,7 @@ public static class AddMetadataEndpoint
     public static async Task<Ok<Guid>> Handle(
         ISmartMeterCreateService smartMeterCreateService,
         [FromRoute] Guid id,
-        [FromBody] MetadataCreateDto metadataCreateDto,
-        ClaimsPrincipal user)
+        [FromBody] MetadataCreateDto metadataCreateDto)
     {
         var smartMeterId = await smartMeterCreateService.AddMetadataAsync(id, metadataCreateDto);
         return TypedResults.Ok(smartMeterId);

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/RemoveMetadataEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/RemoveMetadataEndpoint.cs
@@ -15,7 +15,7 @@ public static class RemoveMetadataEndpoint
         [FromRoute] Guid metadataId,
         ClaimsPrincipal user)
     {
-        await smartMeterDeleteService.RemoveMetadataFromSmartMeterAsync(smartMeterId, metadataId);
+        await smartMeterDeleteService.DeleteMetadataAsync(smartMeterId, metadataId);
 
         return TypedResults.NoContent();
     }

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/SmartMeterEndpoints.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/SmartMeterEndpoints.cs
@@ -59,7 +59,16 @@ public static class SmartMeterEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status500InternalServerError);
 
-
+        group.MapPut("/{smartMeterId:guid}/metadata/{metadataId:guid}", UpdateMetadataEndpoint.Handle)
+            .WithName("updateMetadata")
+            .Accepts<MetadataUpdateDto>(contentType)
+            .Produces<Guid>(StatusCodes.Status200OK, contentType)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
+            
         return app;
     }
 }

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/SmartMeterEndpoints.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/SmartMeterEndpoints.cs
@@ -68,7 +68,7 @@ public static class SmartMeterEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesProblem(StatusCodes.Status500InternalServerError);
-            
+
         return app;
     }
 }

--- a/src/SMAIAXBackend.API/Endpoints/SmartMeter/UpdateMetadataEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/SmartMeter/UpdateMetadataEndpoint.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+using SMAIAXBackend.Application.DTOs;
+using SMAIAXBackend.Application.Services.Interfaces;
+
+namespace SMAIAXBackend.API.Endpoints.SmartMeter;
+
+public static class UpdateMetadataEndpoint
+{
+    public static async Task<Ok<Guid>> Handle(
+        ISmartMeterUpdateService smartMeterUpdateService,
+        [FromRoute] Guid smartMeterId,
+        [FromRoute] Guid metadataId,
+        [FromBody] MetadataUpdateDto metadataUpdateDto)
+    {
+        var updatedMetadataId =
+            await smartMeterUpdateService.UpdateMetadataAsync(smartMeterId, metadataId, metadataUpdateDto);
+
+        return TypedResults.Ok(updatedMetadataId);
+    }
+}

--- a/src/SMAIAXBackend.API/Middlewares/ExceptionHandlerMiddleware.cs
+++ b/src/SMAIAXBackend.API/Middlewares/ExceptionHandlerMiddleware.cs
@@ -37,7 +37,7 @@ public class ExceptionHandlerMiddleware : IExceptionHandler
                 problemDetails.Title = "Registration Error";
                 break;
             case ExistingPoliciesException:
-            case ArgumentException:
+            case MetadataAlreadyExistsException:
                 problemDetails.Type = "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.8";
                 problemDetails.Status = StatusCodes.Status409Conflict;
                 problemDetails.Title = "Conflict";

--- a/src/SMAIAXBackend.API/Middlewares/ExceptionHandlerMiddleware.cs
+++ b/src/SMAIAXBackend.API/Middlewares/ExceptionHandlerMiddleware.cs
@@ -16,6 +16,7 @@ public class ExceptionHandlerMiddleware : IExceptionHandler
 
         switch (exception)
         {
+            case MetadataNotFoundException:
             case PolicyRequestNotFoundException:
             case SmartMeterNotFoundException:
             case UserNotFoundException:
@@ -35,11 +36,13 @@ public class ExceptionHandlerMiddleware : IExceptionHandler
                 problemDetails.Status = StatusCodes.Status400BadRequest;
                 problemDetails.Title = "Registration Error";
                 break;
+            case ExistingPoliciesException:
             case ArgumentException:
                 problemDetails.Type = "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.8";
                 problemDetails.Status = StatusCodes.Status409Conflict;
                 problemDetails.Title = "Conflict";
                 break;
+            case MetadataIdMismatchException:
             case SmartMeterIdMismatchException:
             case InsufficientLocationDataException:
                 problemDetails.Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1";

--- a/src/SMAIAXBackend.Application/DTOs/MetadataUpdateDto.cs
+++ b/src/SMAIAXBackend.Application/DTOs/MetadataUpdateDto.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+
+using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.ValueObjects;
+using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
+
+namespace SMAIAXBackend.Application.DTOs;
+
+public class MetadataUpdateDto(Guid id, DateTime validFrom, LocationDto location, int householdSize)
+{
+    [Required]
+    public Guid Id { get; set; } = id;
+
+    [Required]
+    public DateTime ValidFrom { get; set; } = validFrom;
+
+    [Required]
+    public LocationDto Location { get; set; } = location;
+
+    [Required]
+    public int HouseholdSize { get; set; } = householdSize;
+
+    public static Metadata FromMetadataDto(MetadataUpdateDto metadataUpdateDto, SmartMeterId smartMeterId)
+    {
+        return Metadata.Create(new MetadataId(metadataUpdateDto.Id), metadataUpdateDto.ValidFrom,
+            new Location(metadataUpdateDto.Location.StreetName, metadataUpdateDto.Location.City,
+                metadataUpdateDto.Location.State, metadataUpdateDto.Location.Country,
+                metadataUpdateDto.Location.Continent), metadataUpdateDto.HouseholdSize, smartMeterId);
+    }
+}

--- a/src/SMAIAXBackend.Application/Exceptions/ExistingPoliciesException.cs
+++ b/src/SMAIAXBackend.Application/Exceptions/ExistingPoliciesException.cs
@@ -1,0 +1,7 @@
+namespace SMAIAXBackend.Application.Exceptions;
+
+public class ExistingPoliciesException(Guid smartMeterId) : Exception
+{
+    public override string Message { get; } =
+        $"Cannot update metadata because there are existing policies for smart meter with id '{smartMeterId}'";
+}

--- a/src/SMAIAXBackend.Application/Exceptions/MetadataAlreadyExistsException.cs
+++ b/src/SMAIAXBackend.Application/Exceptions/MetadataAlreadyExistsException.cs
@@ -1,0 +1,6 @@
+namespace SMAIAXBackend.Application.Exceptions;
+
+public class MetadataAlreadyExistsException(Guid metadataId) : Exception
+{
+    public override string Message { get; } = $"Metadata with id '{metadataId}' already exists";
+}

--- a/src/SMAIAXBackend.Application/Exceptions/MetadataIdMismatchException.cs
+++ b/src/SMAIAXBackend.Application/Exceptions/MetadataIdMismatchException.cs
@@ -1,0 +1,6 @@
+namespace SMAIAXBackend.Application.Exceptions;
+
+public class MetadataIdMismatchException(Guid metadataIdExpected, Guid metadataIdActual) : Exception
+{
+    public override string Message { get; } = $"MetadataId `{metadataIdExpected}` in the path does not match the MetadataId `{metadataIdActual}` in the body.";
+}

--- a/src/SMAIAXBackend.Application/Exceptions/MetadataNotFoundException.cs
+++ b/src/SMAIAXBackend.Application/Exceptions/MetadataNotFoundException.cs
@@ -1,0 +1,6 @@
+namespace SMAIAXBackend.Application.Exceptions;
+
+public class MetadataNotFoundException(Guid metadataId) : Exception
+{
+    public override string Message { get; } = $"Metadata with id '{metadataId} not found.";
+}

--- a/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterCreateService.cs
+++ b/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterCreateService.cs
@@ -68,8 +68,17 @@ public class SmartMeterCreateService(
             metadataCreateDto.Location.State, metadataCreateDto.Location.Country, metadataCreateDto.Location.Continent);
         var metadata = Metadata.Create(metadataId, metadataCreateDto.ValidFrom, location,
             metadataCreateDto.HouseholdSize, smartMeter.Id);
-        smartMeter.AddMetadata(metadata);
 
+        try
+        {
+            smartMeter.AddMetadata(metadata);
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogError(ex, "Metadata with id '{MetadataId}' already exists", metadataId.Id);
+            throw new MetadataAlreadyExistsException(metadataId.Id);
+        }
+        
         await smartMeterRepository.UpdateAsync(smartMeter);
 
         return smartMeterId;

--- a/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterCreateService.cs
+++ b/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterCreateService.cs
@@ -78,7 +78,7 @@ public class SmartMeterCreateService(
             logger.LogError(ex, "Metadata with id '{MetadataId}' already exists", metadataId.Id);
             throw new MetadataAlreadyExistsException(metadataId.Id);
         }
-        
+
         await smartMeterRepository.UpdateAsync(smartMeter);
 
         return smartMeterId;

--- a/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterDeleteService.cs
+++ b/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterDeleteService.cs
@@ -31,7 +31,7 @@ public class SmartMeterDeleteService(
             logger.LogError(ex, "Metadata with id '{MetadataId}' not found", metadataId);
             throw new MetadataNotFoundException(metadataId);
         }
-        
+
         await smartMeterRepository.UpdateAsync(smartMeter);
     }
 }

--- a/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterDeleteService.cs
+++ b/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterDeleteService.cs
@@ -11,7 +11,7 @@ public class SmartMeterDeleteService(
     ISmartMeterRepository smartMeterRepository,
     ILogger<SmartMeterDeleteService> logger) : ISmartMeterDeleteService
 {
-    public async Task RemoveMetadataFromSmartMeterAsync(Guid smartMeterId, Guid metadataId)
+    public async Task DeleteMetadataAsync(Guid smartMeterId, Guid metadataId)
     {
         var smartMeter =
             await smartMeterRepository.GetSmartMeterByIdAsync(new SmartMeterId(smartMeterId));
@@ -22,7 +22,16 @@ public class SmartMeterDeleteService(
             throw new SmartMeterNotFoundException(smartMeterId);
         }
 
-        smartMeter.RemoveMetadata(new MetadataId(metadataId));
+        try
+        {
+            smartMeter.RemoveMetadata(new MetadataId(metadataId));
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogError(ex, "Metadata with id '{MetadataId}' not found", metadataId);
+            throw new MetadataNotFoundException(metadataId);
+        }
+        
         await smartMeterRepository.UpdateAsync(smartMeter);
     }
 }

--- a/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterUpdateService.cs
+++ b/src/SMAIAXBackend.Application/Services/Implementations/SmartMeterUpdateService.cs
@@ -10,6 +10,7 @@ namespace SMAIAXBackend.Application.Services.Implementations;
 
 public class SmartMeterUpdateService(
     ISmartMeterRepository smartMeterRepository,
+    IPolicyRepository policyRepository,
     ILogger<SmartMeterUpdateService> logger) : ISmartMeterUpdateService
 {
     public async Task<Guid> UpdateSmartMeterAsync(
@@ -37,5 +38,51 @@ public class SmartMeterUpdateService(
         await smartMeterRepository.UpdateAsync(smartMeter);
 
         return smartMeterIdExpected;
+    }
+
+    public async Task<Guid> UpdateMetadataAsync(Guid smartMeterId, Guid metadataId, MetadataUpdateDto metadataUpdateDto)
+    {
+        if (metadataId != metadataUpdateDto.Id)
+        {
+            logger.LogWarning(
+                "MetadataId `{MetadataIdExpected}` in the path does not match the MetadataId `{MetadataIdActual}` in the body",
+                metadataId, metadataUpdateDto.Id);
+            throw new MetadataIdMismatchException(metadataId, metadataUpdateDto.Id);
+        }
+
+        var smartMeter =
+            await smartMeterRepository.GetSmartMeterByIdAsync(new SmartMeterId(smartMeterId));
+
+        if (smartMeter == null)
+        {
+            logger.LogError("Smart meter with id '{SmartMeterId} not found.", smartMeterId);
+            throw new SmartMeterNotFoundException(smartMeterId);
+        }
+
+        var policies = await policyRepository.GetPoliciesBySmartMeterIdAsync(smartMeter.Id);
+
+        if (policies.Count != 0)
+        {
+            logger.LogWarning(
+                "Cannot update metadata because there are existing policies for smart meter with id  {SmartMeterId}",
+                smartMeterId);
+            throw new ExistingPoliciesException(smartMeterId);
+        }
+
+        var metadata = MetadataUpdateDto.FromMetadataDto(metadataUpdateDto, smartMeter.Id);
+
+        try
+        {
+            smartMeter.UpdateMetadata(metadata);
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogError(ex, "Metadata with id '{MetadataId}' not found", metadataId);
+            throw new MetadataNotFoundException(metadataId);
+        }
+
+        await smartMeterRepository.UpdateAsync(smartMeter);
+
+        return metadataId;
     }
 }

--- a/src/SMAIAXBackend.Application/Services/Interfaces/ISmartMeterDeleteService.cs
+++ b/src/SMAIAXBackend.Application/Services/Interfaces/ISmartMeterDeleteService.cs
@@ -2,5 +2,5 @@ namespace SMAIAXBackend.Application.Services.Interfaces;
 
 public interface ISmartMeterDeleteService
 {
-    Task RemoveMetadataFromSmartMeterAsync(Guid smartMeterId, Guid metadataId);
+    Task DeleteMetadataAsync(Guid smartMeterId, Guid metadataId);
 }

--- a/src/SMAIAXBackend.Application/Services/Interfaces/ISmartMeterUpdateService.cs
+++ b/src/SMAIAXBackend.Application/Services/Interfaces/ISmartMeterUpdateService.cs
@@ -5,4 +5,5 @@ namespace SMAIAXBackend.Application.Services.Interfaces;
 public interface ISmartMeterUpdateService
 {
     Task<Guid> UpdateSmartMeterAsync(Guid smartMeterIdExpected, SmartMeterUpdateDto smartMeterUpdateDto);
+    Task<Guid> UpdateMetadataAsync(Guid smartMeterId, Guid metadataId, MetadataUpdateDto metadataUpdateDto);
 }

--- a/src/SMAIAXBackend.Domain/Model/Entities/SmartMeter.cs
+++ b/src/SMAIAXBackend.Domain/Model/Entities/SmartMeter.cs
@@ -49,6 +49,18 @@ public sealed class SmartMeter : IEquatable<SmartMeter>
         Metadata.Remove(metadata);
     }
 
+    public void UpdateMetadata(Metadata metadata)
+    {
+        var existingMetadata = Metadata.Find(m => m.Id.Equals(metadata.Id));
+        if (existingMetadata == null)
+        {
+            throw new ArgumentException("Metadata not found");
+        }
+
+        Metadata.Remove(existingMetadata);
+        Metadata.Add(metadata);
+    }
+
     public void Update(string name)
     {
         Name = name;

--- a/tests/SMAIAXBackend.Application.UnitTests/SmartMeterCreateServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/SmartMeterCreateServiceTests.cs
@@ -112,7 +112,7 @@ public class SmartMeterCreateServiceTests
         Assert.ThrowsAsync<SmartMeterNotFoundException>(async () =>
             await _smartMeterCreateService.AddMetadataAsync(smartMeterId.Id, metadataCreateDto));
     }
-    
+
     [Test]
     public void
         GivenSmartMeterIdAndExistingMetadataCreateDto_WhenAddMetadata_ThenMetadataAlreadyExistsExceptionIsThrown()

--- a/tests/SMAIAXBackend.Application.UnitTests/SmartMeterCreateServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/SmartMeterCreateServiceTests.cs
@@ -7,6 +7,7 @@ using SMAIAXBackend.Application.Exceptions;
 using SMAIAXBackend.Application.Services.Implementations;
 using SMAIAXBackend.Domain.Model.Entities;
 using SMAIAXBackend.Domain.Model.Enums;
+using SMAIAXBackend.Domain.Model.ValueObjects;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 using SMAIAXBackend.Domain.Repositories;
 using SMAIAXBackend.Domain.Repositories.Transactions;
@@ -109,6 +110,30 @@ public class SmartMeterCreateServiceTests
 
         // Then ... Then
         Assert.ThrowsAsync<SmartMeterNotFoundException>(async () =>
+            await _smartMeterCreateService.AddMetadataAsync(smartMeterId.Id, metadataCreateDto));
+    }
+    
+    [Test]
+    public void
+        GivenSmartMeterIdAndExistingMetadataCreateDto_WhenAddMetadata_ThenMetadataAlreadyExistsExceptionIsThrown()
+    {
+        // Given
+        var smartMeterId = new SmartMeterId(Guid.NewGuid());
+        var metadataId = new MetadataId(Guid.NewGuid());
+        var metadataCreateDto = new MetadataCreateDto(DateTime.UtcNow,
+            new LocationDto("Test Street", "Test City", "Test State", "Test Country", Continent.Europe), 1);
+        var smartMeter = SmartMeter.Create(smartMeterId, "Test Smart Meter", []);
+        var existingMetadata = Metadata.Create(metadataId, DateTime.UtcNow,
+            new Location("Test Street", "Test City", "Test State", "Test Country", Continent.Europe), 1, smartMeterId);
+
+        smartMeter.AddMetadata(existingMetadata);
+
+        _smartMeterRepositoryMock.Setup(repo => repo.GetSmartMeterByIdAsync(smartMeterId))
+            .ReturnsAsync(smartMeter);
+        _smartMeterRepositoryMock.Setup(repo => repo.NextMetadataIdentity()).Returns(metadataId);
+
+        // When ... Then
+        Assert.ThrowsAsync<MetadataAlreadyExistsException>(async () =>
             await _smartMeterCreateService.AddMetadataAsync(smartMeterId.Id, metadataCreateDto));
     }
 }

--- a/tests/SMAIAXBackend.Application.UnitTests/SmartMeterDeleteServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/SmartMeterDeleteServiceTests.cs
@@ -61,7 +61,7 @@ public class SmartMeterDeleteServiceTests
         Assert.ThrowsAsync<SmartMeterNotFoundException>(() =>
             _smartMeterDeleteService.DeleteMetadataAsync(smartMeterId.Id, metadataId.Id));
     }
-    
+
     [Test]
     public void GivenSmartMeterIdAndNonExistentMetadataId_WhenRemoveMetadataFromSmartMeter_ThenMetadataNotFoundExceptionIsThrown()
     {

--- a/tests/SMAIAXBackend.Application.UnitTests/SmartMeterDeleteServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/SmartMeterDeleteServiceTests.cs
@@ -41,14 +41,14 @@ public class SmartMeterDeleteServiceTests
             .ReturnsAsync(smartMeter);
 
         // When
-        await _smartMeterDeleteService.RemoveMetadataFromSmartMeterAsync(smartMeter.Id.Id, metadata.Id.Id);
+        await _smartMeterDeleteService.DeleteMetadataAsync(smartMeter.Id.Id, metadata.Id.Id);
 
         // Then
         Assert.That(smartMeter.Metadata, Is.Empty);
     }
 
     [Test]
-    public void GivenSmartMeterIdAndNonExistentMetadataIdAndUserId_WhenRemoveMetadataFromSmartMeter_ThenSmartMeterNotFoundExceptionIsThrown()
+    public void GivenNonExistentSmartMeterIdAndMetadataIdAndUserId_WhenRemoveMetadataFromSmartMeter_ThenSmartMeterNotFoundExceptionIsThrown()
     {
         // Given
         var smartMeterId = new SmartMeterId(Guid.NewGuid());
@@ -59,6 +59,22 @@ public class SmartMeterDeleteServiceTests
 
         // When ... Then
         Assert.ThrowsAsync<SmartMeterNotFoundException>(() =>
-            _smartMeterDeleteService.RemoveMetadataFromSmartMeterAsync(smartMeterId.Id, metadataId.Id));
+            _smartMeterDeleteService.DeleteMetadataAsync(smartMeterId.Id, metadataId.Id));
+    }
+    
+    [Test]
+    public void GivenSmartMeterIdAndNonExistentMetadataId_WhenRemoveMetadataFromSmartMeter_ThenMetadataNotFoundExceptionIsThrown()
+    {
+        // Given
+        var smartMeterId = new SmartMeterId(Guid.NewGuid());
+        var metadataId = new MetadataId(Guid.NewGuid());
+        var smartMeter = SmartMeter.Create(smartMeterId, "Smart Meter", []);
+
+        _smartMeterRepositoryMock.Setup(x => x.GetSmartMeterByIdAsync(smartMeterId))
+            .ReturnsAsync(smartMeter);
+
+        // When ... Then
+        Assert.ThrowsAsync<MetadataNotFoundException>(() =>
+            _smartMeterDeleteService.DeleteMetadataAsync(smartMeterId.Id, metadataId.Id));
     }
 }

--- a/tests/SMAIAXBackend.Application.UnitTests/SmartMeterUpdateTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/SmartMeterUpdateTests.cs
@@ -6,6 +6,8 @@ using SMAIAXBackend.Application.DTOs;
 using SMAIAXBackend.Application.Exceptions;
 using SMAIAXBackend.Application.Services.Implementations;
 using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.Enums;
+using SMAIAXBackend.Domain.Model.ValueObjects;
 using SMAIAXBackend.Domain.Model.ValueObjects.Ids;
 using SMAIAXBackend.Domain.Repositories;
 
@@ -15,6 +17,7 @@ namespace SMAIAXBackend.Application.UnitTests;
 public class SmartMeterUpdateTests
 {
     private Mock<ISmartMeterRepository> _smartMeterRepositoryMock;
+    private Mock<IPolicyRepository> _policyRepositoryMock;
     private Mock<ILogger<SmartMeterUpdateService>> _loggerMock;
     private SmartMeterUpdateService _smartMeterUpdateService;
 
@@ -22,8 +25,10 @@ public class SmartMeterUpdateTests
     public void Setup()
     {
         _smartMeterRepositoryMock = new Mock<ISmartMeterRepository>();
+        _policyRepositoryMock = new Mock<IPolicyRepository>();
         _loggerMock = new Mock<ILogger<SmartMeterUpdateService>>();
-        _smartMeterUpdateService = new SmartMeterUpdateService(_smartMeterRepositoryMock.Object, _loggerMock.Object);
+        _smartMeterUpdateService = new SmartMeterUpdateService(_smartMeterRepositoryMock.Object,
+            _policyRepositoryMock.Object, _loggerMock.Object);
     }
 
     [Test]
@@ -73,5 +78,109 @@ public class SmartMeterUpdateTests
         // When ... Then
         Assert.ThrowsAsync<SmartMeterNotFoundException>(async () =>
             await _smartMeterUpdateService.UpdateSmartMeterAsync(smartMeterIdExpected, smartMeterUpdateDto));
+    }
+
+    [Test]
+    public async Task GivenSmartMeterIdAndMetadataUpdateDto_WhenUpdateMetadata_ThenMetadataIdIsReturned()
+    {
+        // Given
+        var smartMeterId = Guid.NewGuid();
+        var metadataId = Guid.NewGuid();
+        var metadataUpdateDto = new MetadataUpdateDto(metadataId, DateTime.UtcNow,
+            new LocationDto("Updated street", "Updated city", "Updated state", "Updated country", Continent.Asia), 5);
+        var smartMeter = SmartMeter.Create(new SmartMeterId(smartMeterId), "SmartMeter", []);
+        var metadata = Metadata.Create(new MetadataId(metadataId), DateTime.UtcNow,
+            new Location("Some street", "Some city", "Some state", "Some country", Continent.Europe), 4, smartMeter.Id);
+        smartMeter.AddMetadata(metadata);
+
+        _smartMeterRepositoryMock.Setup(repo => repo.GetSmartMeterByIdAsync(new SmartMeterId(smartMeterId)))
+            .ReturnsAsync(smartMeter);
+        _policyRepositoryMock.Setup(repo => repo.GetPoliciesBySmartMeterIdAsync(new SmartMeterId(smartMeterId)))
+            .ReturnsAsync([]);
+
+        // When
+        var metadataIdActual =
+            await _smartMeterUpdateService.UpdateMetadataAsync(smartMeterId, metadataId, metadataUpdateDto);
+
+        // Then
+        Assert.That(metadataIdActual, Is.EqualTo(metadataId));
+    }
+
+    [Test]
+    public void GivenNotMatchingMetadataIds_WhenUpdateMetadata_ThenMetadataIdMismatchExceptionIsThrown()
+    {
+        // Given
+        var smartMeterId = Guid.NewGuid();
+        var metadataId = Guid.NewGuid();
+        var metadataUpdateDto = new MetadataUpdateDto(Guid.NewGuid(), DateTime.UtcNow,
+            new LocationDto("Updated street", "Updated city", "Updated state", "Updated country", Continent.Asia), 5);
+
+        // When ... Then
+        Assert.ThrowsAsync<MetadataIdMismatchException>(async () =>
+            await _smartMeterUpdateService.UpdateMetadataAsync(smartMeterId, metadataId, metadataUpdateDto));
+    }
+
+    [Test]
+    public void GivenNonExistentSmartMeterId_WhenUpdateMetadata_ThenSmartMeterNotFoundExceptionIsThrown()
+    {
+        // Given
+        var smartMeterId = Guid.NewGuid();
+        var metadataId = Guid.NewGuid();
+        var metadataUpdateDto = new MetadataUpdateDto(metadataId, DateTime.UtcNow, new LocationDto("Updated street",
+            "Updated city",
+            "Updated state", "Updated country", Continent.Asia), 5);
+
+        _smartMeterRepositoryMock.Setup(repo => repo.GetSmartMeterByIdAsync(new SmartMeterId(smartMeterId)))
+            .ReturnsAsync((SmartMeter)null!);
+
+        // When ... Then
+        Assert.ThrowsAsync<SmartMeterNotFoundException>(async () =>
+            await _smartMeterUpdateService.UpdateMetadataAsync(smartMeterId, metadataId, metadataUpdateDto));
+    }
+
+    [Test]
+    public void GivenExistingPolicies_WhenUpdateMetadata_ThenExistingPoliciesExceptionIsThrown()
+    {
+        // Given
+        var smartMeterId = Guid.NewGuid();
+        var metadataId = Guid.NewGuid();
+        var metadataUpdateDto = new MetadataUpdateDto(metadataId, DateTime.UtcNow, new LocationDto("Updated street",
+            "Updated city",
+            "Updated state", "Updated country", Continent.Asia), 5);
+        var smartMeter = SmartMeter.Create(new SmartMeterId(smartMeterId), "SmartMeter", []);
+        var policies = new List<Policy>
+        {
+            Policy.Create(new PolicyId(Guid.NewGuid()), MeasurementResolution.Hour, LocationResolution.City, 10.0m,
+                new SmartMeterId(smartMeterId))
+        };
+
+        _smartMeterRepositoryMock.Setup(repo => repo.GetSmartMeterByIdAsync(new SmartMeterId(smartMeterId)))
+            .ReturnsAsync(smartMeter);
+        _policyRepositoryMock.Setup(repo => repo.GetPoliciesBySmartMeterIdAsync(new SmartMeterId(smartMeterId)))
+            .ReturnsAsync(policies);
+
+        // When ... Then
+        Assert.ThrowsAsync<ExistingPoliciesException>(async () =>
+            await _smartMeterUpdateService.UpdateMetadataAsync(smartMeterId, metadataId, metadataUpdateDto));
+    }
+
+    [Test]
+    public void GivenNonExistentMetadata_WhenUpdateMetadata_ThenMetadataNotFoundExceptionIsThrown()
+    {
+        // Given
+        var smartMeterId = Guid.NewGuid();
+        var metadataId = Guid.NewGuid();
+        var metadataUpdateDto = new MetadataUpdateDto(metadataId, DateTime.UtcNow, new LocationDto("Updated street", "Updated city",
+            "Updated state", "Updated country", Continent.Asia), 5);
+        var smartMeter = SmartMeter.Create(new SmartMeterId(smartMeterId), "SmartMeter", []);
+
+        _smartMeterRepositoryMock.Setup(repo => repo.GetSmartMeterByIdAsync(new SmartMeterId(smartMeterId)))
+            .ReturnsAsync(smartMeter);
+        _policyRepositoryMock.Setup(repo => repo.GetPoliciesBySmartMeterIdAsync(new SmartMeterId(smartMeterId)))
+            .ReturnsAsync([]);
+
+        // When ... Then
+        Assert.ThrowsAsync<MetadataNotFoundException>(async () =>
+            await _smartMeterUpdateService.UpdateMetadataAsync(smartMeterId, metadataId, metadataUpdateDto));
     }
 }

--- a/tests/SMAIAXBackend.Domain.UnitTests/Model/SmartMeterTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Model/SmartMeterTests.cs
@@ -124,4 +124,41 @@ public class SmartMeterTests
         // When ... Then
         Assert.Throws<ArgumentException>(() => smartMeter.RemoveMetadata(new MetadataId(Guid.NewGuid())));
     }
+    
+    [Test]
+    public void GivenSmartMeterAndUpdatedMetadata_WhenUpdateMetadata_ThenMetadataIsUpdated()
+    {
+        // Given
+        var smartMeter = SmartMeter.Create(new SmartMeterId(Guid.NewGuid()), "SmartMeter", []);
+        var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
+            new Location("Some street", "Some city", "Some state", "Some country", Continent.Europe),
+            4, smartMeter.Id);
+        smartMeter.AddMetadata(metadata);
+        var updatedMetadata = Metadata.Create(metadata.Id, DateTime.UtcNow,
+            new Location("Updated street", "Updated city", "Updated state", "Updated country", Continent.Asia),
+            5, smartMeter.Id);
+
+        // When
+        smartMeter.UpdateMetadata(updatedMetadata);
+
+        // Then
+        Assert.Multiple(() =>
+        {
+            Assert.That(smartMeter.Metadata, Has.Count.EqualTo(1));
+            Assert.That(smartMeter.Metadata[0], Is.EqualTo(updatedMetadata));
+        });
+    }
+
+    [Test]
+    public void GivenSmartMeterAndNonExistentMetadata_WhenUpdateMetadata_ThenArgumentExceptionIsThrown()
+    {
+        // Given
+        var smartMeter = SmartMeter.Create(new SmartMeterId(Guid.NewGuid()), "SmartMeter", []);
+        var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
+            new Location("Some street", "Some city", "Some state", "Some country", Continent.Europe),
+            4, smartMeter.Id);
+
+        // When ... Then
+        Assert.Throws<ArgumentException>(() => smartMeter.UpdateMetadata(metadata));
+    }
 }

--- a/tests/SMAIAXBackend.Domain.UnitTests/Model/SmartMeterTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Model/SmartMeterTests.cs
@@ -124,7 +124,7 @@ public class SmartMeterTests
         // When ... Then
         Assert.Throws<ArgumentException>(() => smartMeter.RemoveMetadata(new MetadataId(Guid.NewGuid())));
     }
-    
+
     [Test]
     public void GivenSmartMeterAndUpdatedMetadata_WhenUpdateMetadata_ThenMetadataIsUpdated()
     {


### PR DESCRIPTION
- **feat(smartmeter): implement edit metadata**
  - Added UpdateMetadataEndpoint and mapped it in SmartMeterEndpoints
  - Added UpdateMetadata method to SmartMeterUpdateService
  - Created ExistingPoliciesException for the case that there are existing policies for the smart meter
  - Created MetadataIdMismatchException for the case that the path and dto id don't match
  - Created MetadataNotFoundException for the case that the metadata to be updated does not exist.
  - Implemented unit and integration tests.
  

- **chore: remove unused variable in AddMetadataEndpoint**
  

- **refactor(smartmeter): update services to catch domain exceptions**
  - Added try and catch to SmartMeterCreateService and SmartMeterDeleteService to catch the metadata related domain exceptions.
  - Added throwing custom exceptions from application layer instead of catching ArgumentException from the domain layer in the ExceptionHandlerMiddleware
  - Added unit tests
  