### PR TITLE
Fix docker network for mqtt broker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@
       retries: 5
     command: >
       sh -c "rabbitmq-plugins enable rabbitmq_management rabbitmq_mqtt && rabbitmq-server"
+    networks:
+      - smaiax-backend-network
 
 networks:
   smaiax-backend-network:


### PR DESCRIPTION
fix(docker): add rabbitmq to smaiax-backend-network