### PR TITLE
Extend policy filtering

### DIFF
--- a/src/SMAIAXBackend.API/Endpoints/Policy/SearchPoliciesEndpoint.cs
+++ b/src/SMAIAXBackend.API/Endpoints/Policy/SearchPoliciesEndpoint.cs
@@ -12,9 +12,10 @@ public static class SearchPoliciesEndpoint
     public static async Task<Ok<List<PolicyDto>>> Handle(
         IPolicyListService policyListService,
         [FromQuery] decimal? maxPrice,
-        [FromQuery] MeasurementResolution? measurementResolution)
+        [FromQuery] MeasurementResolution? measurementResolution,
+        [FromQuery] LocationResolution? locationResolution)
     {
-        var policies = await policyListService.GetFilteredPoliciesAsync(maxPrice, measurementResolution);
+        var policies = await policyListService.GetFilteredPoliciesAsync(maxPrice, measurementResolution, locationResolution);
 
         return TypedResults.Ok(policies);
     }

--- a/src/SMAIAXBackend.Application/Services/Implementations/PolicyListService.cs
+++ b/src/SMAIAXBackend.Application/Services/Implementations/PolicyListService.cs
@@ -32,7 +32,7 @@ public class PolicyListService(
     }
 
     public async Task<List<PolicyDto>> GetFilteredPoliciesAsync(decimal? maxPrice,
-        MeasurementResolution? measurementResolution)
+        MeasurementResolution? measurementResolution, LocationResolution? locationResolution)
     {
         var matchingPolicies = new List<PolicyDto>();
         ISpecification<Policy> specification = new BaseSpecification<Policy>();
@@ -48,6 +48,13 @@ public class PolicyListService(
             var measurementResolutionSpecification =
                 new MeasurementResolutionSpecification(measurementResolution.Value);
             specification = new AndSpecification<Policy>(specification, measurementResolutionSpecification);
+        }
+
+        if (locationResolution.HasValue)
+        {
+            var locationResolutionSpecification =
+                new PolicyLocationResolutionSpecification(locationResolution.Value);
+            specification = new AndSpecification<Policy>(specification, locationResolutionSpecification);
         }
 
         var currentTenant = await tenantContextService.GetCurrentTenantAsync();
@@ -93,7 +100,7 @@ public class PolicyListService(
         }
 
         var timeSpans = new List<(DateTime?, DateTime?)>();
-        var specification = new LocationResolutionSpecification(policy.LocationResolution);
+        var specification = new MetadataLocationResolutionSpecification(policy.LocationResolution);
         for (var i = 0; i < metadata!.Count; i += 1)
         {
             if (!specification.IsSatisfiedBy(metadata[i]))

--- a/src/SMAIAXBackend.Application/Services/Interfaces/IPolicyListService.cs
+++ b/src/SMAIAXBackend.Application/Services/Interfaces/IPolicyListService.cs
@@ -8,6 +8,6 @@ public interface IPolicyListService
 {
     Task<List<PolicyDto>> GetPoliciesBySmartMeterIdAsync(SmartMeterId smartMeterId);
     Task<List<PolicyDto>> GetPoliciesAsync();
-    Task<List<PolicyDto>> GetFilteredPoliciesAsync(decimal? maxPrice, MeasurementResolution? measurementResolution);
+    Task<List<PolicyDto>> GetFilteredPoliciesAsync(decimal? maxPrice, MeasurementResolution? measurementResolution, LocationResolution? locationResolution);
     Task<List<MeasurementDto>> GetMeasurementsByPolicyIdAsync(Guid policyId);
 }

--- a/src/SMAIAXBackend.Domain/Model/Enums/LocationResolution.cs
+++ b/src/SMAIAXBackend.Domain/Model/Enums/LocationResolution.cs
@@ -2,10 +2,10 @@ namespace SMAIAXBackend.Domain.Model.Enums;
 
 public enum LocationResolution
 {
-    None,
     StreetName,
     City,
     State,
     Country,
-    Continent
+    Continent,
+    None
 }

--- a/src/SMAIAXBackend.Domain/Specifications/MetadataLocationResolutionSpecification.cs
+++ b/src/SMAIAXBackend.Domain/Specifications/MetadataLocationResolutionSpecification.cs
@@ -3,7 +3,7 @@ using SMAIAXBackend.Domain.Model.Enums;
 
 namespace SMAIAXBackend.Domain.Specifications;
 
-public class LocationResolutionSpecification(LocationResolution locationResolution) : ISpecification<Metadata>
+public class MetadataLocationResolutionSpecification(LocationResolution locationResolution) : ISpecification<Metadata>
 {
     public bool IsSatisfiedBy(Metadata metadata)
     {

--- a/src/SMAIAXBackend.Domain/Specifications/PolicyLocationResolutionSpecification.cs
+++ b/src/SMAIAXBackend.Domain/Specifications/PolicyLocationResolutionSpecification.cs
@@ -1,0 +1,12 @@
+using SMAIAXBackend.Domain.Model.Entities;
+using SMAIAXBackend.Domain.Model.Enums;
+
+namespace SMAIAXBackend.Domain.Specifications;
+
+public class PolicyLocationResolutionSpecification(LocationResolution locationResolution) : ISpecification<Policy>
+{
+    public bool IsSatisfiedBy(Policy policy)
+    {
+        return policy.LocationResolution <= locationResolution;
+    }
+}

--- a/tests/SMAIAXBackend.Application.UnitTests/PolicyListServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/PolicyListServiceTests.cs
@@ -151,7 +151,7 @@ public class PolicyListServiceTests
         _policyRepositoryMock.Setup(repo => repo.GetPoliciesByTenantAsync(tenants[1])).ReturnsAsync([]);
 
         // When
-        var policiesActual = await _policyListService.GetFilteredPoliciesAsync(maxPrice, measurementResolution);
+        var policiesActual = await _policyListService.GetFilteredPoliciesAsync(maxPrice, measurementResolution, null);
 
         // Then
         Assert.That(policiesActual, Is.Not.Null);
@@ -176,7 +176,7 @@ public class PolicyListServiceTests
         _policyRepositoryMock.Setup(repo => repo.GetPoliciesByTenantAsync(It.IsAny<Tenant>())).ReturnsAsync([]);
 
         // When
-        var policiesActual = await _policyListService.GetFilteredPoliciesAsync(maxPrice, measurementResolution);
+        var policiesActual = await _policyListService.GetFilteredPoliciesAsync(maxPrice, measurementResolution, null);
 
         // Then
         Assert.That(policiesActual, Is.Not.Null);

--- a/tests/SMAIAXBackend.Domain.UnitTests/Specifications/MetadataLocationResolutionSpecificationTests.cs
+++ b/tests/SMAIAXBackend.Domain.UnitTests/Specifications/MetadataLocationResolutionSpecificationTests.cs
@@ -7,13 +7,13 @@ using SMAIAXBackend.Domain.Specifications;
 namespace SMAIAXBackend.Domain.UnitTests.Specifications;
 
 [TestFixture]
-public class LocationResolutionSpecificationTests
+public class MetadataLocationResolutionSpecificationTests
 {
     [Test]
     public void Given_LocationResolutionIsEqual_When_IsSatisfiedByIsCalled_Then_ReturnsTrue()
     {
         // Given
-        var specification = new LocationResolutionSpecification(LocationResolution.Country);
+        var specification = new MetadataLocationResolutionSpecification(LocationResolution.Country);
         var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
             new Location(null, null, null, "USA", Continent.NorthAmerica), null, new SmartMeterId(Guid.NewGuid()));
 
@@ -28,7 +28,7 @@ public class LocationResolutionSpecificationTests
     public void Given_LocationResolutionIsLower_When_IsSatisfiedByIsCalled_Then_ReturnsTrue()
     {
         // Given
-        var specification = new LocationResolutionSpecification(LocationResolution.Country);
+        var specification = new MetadataLocationResolutionSpecification(LocationResolution.Country);
         var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
             new Location(null, "Washington, D.C.", "District of Columbia", "USA", Continent.NorthAmerica), 3,
             new SmartMeterId(Guid.NewGuid()));
@@ -44,7 +44,7 @@ public class LocationResolutionSpecificationTests
     public void Given_LocationResolutionIsHigher_When_IsSatisfiedByIsCalled_Then_ReturnsFalse()
     {
         // Given
-        var specification = new LocationResolutionSpecification(LocationResolution.Country);
+        var specification = new MetadataLocationResolutionSpecification(LocationResolution.Country);
         var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
             new Location(null, null, null, null, Continent.Oceania),
             100, new SmartMeterId(Guid.NewGuid()));
@@ -60,7 +60,7 @@ public class LocationResolutionSpecificationTests
     public void Given_LocationResolutionIsNone_When_IsSatisfiedByIsCalled_Then_ReturnsTrue()
     {
         // Given
-        var specification = new LocationResolutionSpecification(LocationResolution.None);
+        var specification = new MetadataLocationResolutionSpecification(LocationResolution.None);
         var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
             new Location(null, null, null, "Papua New Guinea", Continent.Oceania),
             100, new SmartMeterId(Guid.NewGuid()));
@@ -76,7 +76,7 @@ public class LocationResolutionSpecificationTests
     public void Given_LocationIsNull_When_IsSatisfiedByIsCalled_Then_ReturnsFalse()
     {
         // Given
-        var specification = new LocationResolutionSpecification(LocationResolution.Country);
+        var specification = new MetadataLocationResolutionSpecification(LocationResolution.Country);
         var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow, null, 100,
             new SmartMeterId(Guid.NewGuid()));
 
@@ -91,7 +91,7 @@ public class LocationResolutionSpecificationTests
     public void Given_LocationResolutionIsNoneAndLocationIsNull_When_IsSatisfiedByIsCalled_Then_ReturnsTrue()
     {
         // Given
-        var specification = new LocationResolutionSpecification(LocationResolution.None);
+        var specification = new MetadataLocationResolutionSpecification(LocationResolution.None);
         var metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow, null, 100,
             new SmartMeterId(Guid.NewGuid()));
 


### PR DESCRIPTION
This pull request includes multiple changes to enhance the filtering capabilities of the policy listing service by introducing a new `LocationResolution` parameter. Additionally, several classes and test cases have been updated to accommodate this new parameter.

### Enhancements to Policy Filtering:

* [`src/SMAIAXBackend.API/Endpoints/Policy/SearchPoliciesEndpoint.cs`](diffhunk://#diff-cc120e55f044204e51b2dc3d9c27120b35f4aa1cb01280bc7ca0f9bbc03e2db4L15-R18): Added `LocationResolution` as a query parameter and updated the call to `GetFilteredPoliciesAsync` to include this parameter.
* [`src/SMAIAXBackend.Application/Services/Interfaces/IPolicyListService.cs`](diffhunk://#diff-d222e4559bf771e54771319bf11d3588c796e29bdf8f43542b3f47b61bf79243L11-R11): Updated the `GetFilteredPoliciesAsync` method signature to include the `LocationResolution` parameter.
* [`src/SMAIAXBackend.Application/Services/Implementations/PolicyListService.cs`](diffhunk://#diff-95faf2700b99df304475570fc246979f24409f8205824cc81e2c3c0f985b85a3L35-R35): Modified the `GetFilteredPoliciesAsync` method to handle the new `LocationResolution` parameter and apply the appropriate specification. [[1]](diffhunk://#diff-95faf2700b99df304475570fc246979f24409f8205824cc81e2c3c0f985b85a3L35-R35) [[2]](diffhunk://#diff-95faf2700b99df304475570fc246979f24409f8205824cc81e2c3c0f985b85a3R53-R59)

### Specification and Enum Updates:

* [`src/SMAIAXBackend.Domain/Model/Enums/LocationResolution.cs`](diffhunk://#diff-d0034bd2748d44511eb03d9ba74508b39cb86df03ceef65d2e0f22956084057dL5-R10): Added `None` as a valid value for the `LocationResolution` enum.
* [`src/SMAIAXBackend.Domain/Specifications/MetadataLocationResolutionSpecification.cs`](diffhunk://#diff-b8fd5da345ab09f8fea1d292bc7e88451924dfde220470a60c42909725f0ca12L6-R6): Renamed from `LocationResolutionSpecification` and updated to reflect the new naming convention.
* [`src/SMAIAXBackend.Domain/Specifications/PolicyLocationResolutionSpecification.cs`](diffhunk://#diff-7f897d33bec81a7b17aef491834c60f84e065c9715e355e9a1c69d4225ddffa5R1-R12): Introduced a new specification class to handle policy-specific location resolution filtering.

### Unit Test Adjustments:

* [`tests/SMAIAXBackend.Application.UnitTests/PolicyListServiceTests.cs`](diffhunk://#diff-64a3bd62ad3c3e469e1ecf153e0880d96563aa88cdcad1f2d49e029e4b5c5712L154-R154): Updated test cases to include the new `LocationResolution` parameter in calls to `GetFilteredPoliciesAsync`. [[1]](diffhunk://#diff-64a3bd62ad3c3e469e1ecf153e0880d96563aa88cdcad1f2d49e029e4b5c5712L154-R154) [[2]](diffhunk://#diff-64a3bd62ad3c3e469e1ecf153e0880d96563aa88cdcad1f2d49e029e4b5c5712L179-R179)
* [`tests/SMAIAXBackend.Domain.UnitTests/Specifications/MetadataLocationResolutionSpecificationTests.cs`](diffhunk://#diff-86e3fa1d29a3cd9278d96107eeb4534bf09674e5ec64911f5a44ada5f7534fc6L10-R16): Renamed from `LocationResolutionSpecificationTests` and updated to match the new specification class. [[1]](diffhunk://#diff-86e3fa1d29a3cd9278d96107eeb4534bf09674e5ec64911f5a44ada5f7534fc6L10-R16) [[2]](diffhunk://#diff-86e3fa1d29a3cd9278d96107eeb4534bf09674e5ec64911f5a44ada5f7534fc6L31-R31) [[3]](diffhunk://#diff-86e3fa1d29a3cd9278d96107eeb4534bf09674e5ec64911f5a44ada5f7534fc6L47-R47) [[4]](diffhunk://#diff-86e3fa1d29a3cd9278d96107eeb4534bf09674e5ec64911f5a44ada5f7534fc6L63-R63) [[5]](diffhunk://#diff-86e3fa1d29a3cd9278d96107eeb4534bf09674e5ec64911f5a44ada5f7534fc6L79-R79) [[6]](diffhunk://#diff-86e3fa1d29a3cd9278d96107eeb4534bf09674e5ec64911f5a44ada5f7534fc6L94-R94)