### PR TITLE
Seed test data

### DIFF
--- a/src/SMAIAXBackend.API/appsettings.Development.json
+++ b/src/SMAIAXBackend.API/appsettings.Development.json
@@ -13,12 +13,6 @@
     "AccessTokenExpirationMinutes": 60,
     "RefreshTokenExpirationMinutes": 10080
   },
-  "TestUser": {
-    "Username": "johndoe",
-    "Email": "john.doe@example.com",
-    "Password": "P@ssw0rd",
-    "Database": "tenant_1_db"
-  },
   "Vault": {
     "Address": "http://localhost:8200",
     "Token": "00000000-0000-0000-0000-000000000000",

--- a/src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs
+++ b/src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs
@@ -10,7 +10,7 @@ using SMAIAXBackend.Infrastructure.EntityConfigurations;
 
 namespace SMAIAXBackend.Infrastructure.DbContexts;
 
-public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options, IConfiguration configuration)
+public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
     : IdentityDbContext<IdentityUser>(options)
 {
     public DbSet<User> DomainUsers { get; init; }
@@ -46,29 +46,82 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     {
         var hasher = new PasswordHasher<IdentityUser>();
 
-        var userId = new UserId(Guid.Parse("3c07065a-b964-44a9-9cdf-fbd49d755ea7"));
-        var userName = configuration.GetValue<string>("TestUser:Username");
-        var email = configuration.GetValue<string>("TestUser:Email");
-        var password = configuration.GetValue<string>("TestUser:Password");
-        var tenantDatabase = configuration.GetValue<string>("TestUser:Database");
+        var johnDoeUserId = new UserId(Guid.Parse("3c07065a-b964-44a9-9cdf-fbd49d755ea7"));
+        const string johnDoeUserName = "johndoe";
+        const string johnDoeEmail = "john.doe@example.com";
+        const string johnDoePassword = "P@ssw0rd";
+        const string johnDoeTenantDatabase = "tenant_1_db";
 
-        var testUser = new IdentityUser
+        var johnDoeTestUser = new IdentityUser
         {
-            Id = userId.Id.ToString(),
-            UserName = userName,
-            NormalizedUserName = userName!.ToUpper(),
-            Email = email,
-            NormalizedEmail = email!.ToUpper(),
+            Id = johnDoeUserId.Id.ToString(),
+            UserName = johnDoeUserName,
+            NormalizedUserName = johnDoeUserName!.ToUpper(),
+            Email = johnDoeEmail,
+            NormalizedEmail = johnDoeEmail!.ToUpper(),
         };
-        var passwordHash = hasher.HashPassword(testUser, password!);
-        testUser.PasswordHash = passwordHash;
+        var johnDoePasswordHash = hasher.HashPassword(johnDoeTestUser, johnDoePassword!);
+        johnDoeTestUser.PasswordHash = johnDoePasswordHash;
 
-        var tenant = Tenant.Create(new TenantId(Guid.NewGuid()), "tenant_1_role", tenantDatabase!);
-        var domainUser = User.Create(userId, new Name("John", "Doe"), userName, email, tenant.Id);
+        var johnDoeTenant = Tenant.Create(new TenantId(Guid.NewGuid()), "tenant_1_role", johnDoeTenantDatabase!);
+        var johnDoeDomainUser = User.Create(johnDoeUserId, new Name("John", "Doe"), johnDoeUserName, johnDoeEmail,
+            johnDoeTenant.Id);
 
-        await Users.AddAsync(testUser);
-        await Tenants.AddAsync(tenant);
-        await DomainUsers.AddAsync(domainUser);
+        var janeDoeUserId = new UserId(Guid.Parse("4d07065a-b964-44a9-9cdf-fbd49d755ea8"));
+        const string janeDoeUserName = "janedoe";
+        const string janeDoeEmail = "jane.doe@example.com";
+        const string janeDoePassword = "P@ssw0rd";
+        const string janeDoeTenantDatabase = "tenant_2_db";
+
+        var janeDoeTestUser = new IdentityUser
+        {
+            Id = janeDoeUserId.Id.ToString(),
+            UserName = janeDoeUserName,
+            NormalizedUserName = janeDoeUserName!.ToUpper(),
+            Email = janeDoeEmail,
+            NormalizedEmail = janeDoeEmail!.ToUpper(),
+        };
+        var janeDoePasswordHash = hasher.HashPassword(janeDoeTestUser, janeDoePassword!);
+        janeDoeTestUser.PasswordHash = janeDoePasswordHash;
+
+        var janeDoeTenant = Tenant.Create(new TenantId(Guid.NewGuid()), "tenant_2_role", janeDoeTenantDatabase!);
+        var janeDoeDomainUser = User.Create(janeDoeUserId, new Name("Jane", "Doe"), janeDoeUserName, janeDoeEmail,
+            janeDoeTenant.Id);
+
+        var maxMustermannUserId = new UserId(Guid.Parse("5e07065a-b964-44a9-9cdf-fbd49d755ea9"));
+        const string maxMustermannUserName = "maxmustermann";
+        const string maxMustermannEmail = "max.mustermann@example.com";
+        const string maxMustermannPassword = "P@ssw0rd";
+        const string maxMustermannTenantDatabase = "tenant_3_db";
+
+        var maxMustermannTestUser = new IdentityUser
+        {
+            Id = maxMustermannUserId.Id.ToString(),
+            UserName = maxMustermannUserName,
+            NormalizedUserName = maxMustermannUserName!.ToUpper(),
+            Email = maxMustermannEmail,
+            NormalizedEmail = maxMustermannEmail!.ToUpper(),
+        };
+        var maxMustermannPasswordHash = hasher.HashPassword(maxMustermannTestUser, maxMustermannPassword!);
+        maxMustermannTestUser.PasswordHash = maxMustermannPasswordHash;
+
+        var maxMustermannTenant =
+            Tenant.Create(new TenantId(Guid.NewGuid()), "tenant_3_role", maxMustermannTenantDatabase!);
+        var maxMustermannDomainUser = User.Create(maxMustermannUserId, new Name("Max", "Mustermann"),
+            maxMustermannUserName, maxMustermannEmail, maxMustermannTenant.Id);
+
+        await Users.AddAsync(johnDoeTestUser);
+        await Tenants.AddAsync(johnDoeTenant);
+        await DomainUsers.AddAsync(johnDoeDomainUser);
+
+        await Users.AddAsync(janeDoeTestUser);
+        await Tenants.AddAsync(janeDoeTenant);
+        await DomainUsers.AddAsync(janeDoeDomainUser);
+
+        await Users.AddAsync(maxMustermannTestUser);
+        await Tenants.AddAsync(maxMustermannTenant);
+        await DomainUsers.AddAsync(maxMustermannDomainUser);
+
         await SaveChangesAsync();
     }
 }

--- a/src/SMAIAXBackend.Infrastructure/DbContexts/TenantDbContext.cs
+++ b/src/SMAIAXBackend.Infrastructure/DbContexts/TenantDbContext.cs
@@ -1,4 +1,7 @@
+using System.Globalization;
+
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 using Npgsql;
 
@@ -31,58 +34,150 @@ public class TenantDbContext(DbContextOptions<TenantDbContext> options) : DbCont
         modelBuilder.ApplyConfiguration(new SmartMeterConfiguration());
     }
 
-    public async Task SeedTestData()
+    public async Task SeedTestDataForJohnDoe()
     {
         SmartMeterId smartMeter1Id = new(Guid.Parse("070dec95-56bb-4154-a2c4-c26faf9fff4d"));
         Metadata metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
-            new Location("Hochschulstraße 1", "Dornbirn", "Vorarlberg", "Österreich", Continent.Oceania),
+            new Location("Hochschulstraße 1", "Dornbirn", "Vorarlberg", "Österreich", Continent.Europe),
             4, smartMeter1Id);
         SmartMeter smartMeter1 = SmartMeter.Create(smartMeter1Id, "Smart Meter 1", [metadata]);
-        SmartMeter smartMeter2 = SmartMeter.Create(new SmartMeterId(Guid.NewGuid()), "Smart Meter 2", []);
-
         var policy = Policy.Create(new PolicyId(Guid.NewGuid()), "policy1", MeasurementResolution.Hour,
             LocationResolution.None, 100, smartMeter1Id);
-        var policy2 = Policy.Create(new PolicyId(Guid.NewGuid()), "policy2", MeasurementResolution.Day,
-            LocationResolution.StreetName, 999, smartMeter1Id);
-        var policy3 = Policy.Create(new PolicyId(Guid.NewGuid()), "policy3", MeasurementResolution.Raw,
+        var policy2 = Policy.Create(new PolicyId(Guid.NewGuid()), "policy2", MeasurementResolution.Raw,
             LocationResolution.Continent, 1999, smartMeter1Id);
+
+        SmartMeterId smartMeter2Id = new(Guid.Parse("74b243fd-188e-48a0-b5d1-4916f5464b0a"));
+        SmartMeter smartMeter2 = SmartMeter.Create(smartMeter2Id, "Smart Meter 2", []);
+        var policy3 = Policy.Create(new PolicyId(Guid.NewGuid()), "policy3", MeasurementResolution.Day,
+            LocationResolution.StreetName, 999, smartMeter2Id);
 
         await Policies.AddAsync(policy);
         await Policies.AddAsync(policy2);
         await Policies.AddAsync(policy3);
-
         await SmartMeters.AddAsync(smartMeter1);
         await SmartMeters.AddAsync(smartMeter2);
 
+        await InsertMeasurements(smartMeter1Id);
+        await InsertMeasurements(smartMeter2Id);
+
         await SaveChangesAsync();
+    }
 
-        // Can't be inserted via "AddAsync".
+    public async Task SeedTestDataForJaneDoe()
+    {
+        SmartMeterId smartMeter1Id = new(Guid.Parse("95cc68ed-c94e-40de-851b-b95aaacfb76c"));
+        Metadata metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
+            new Location("Hochschulstraße 1", "Dornbirn", "Vorarlberg", "Österreich", Continent.Europe),
+            2, smartMeter1Id);
+        SmartMeter smartMeter1 = SmartMeter.Create(smartMeter1Id, "Smart Meter 1", [metadata]);
+        var policy = Policy.Create(new PolicyId(Guid.NewGuid()), "policy1", MeasurementResolution.QuarterHour,
+            LocationResolution.None, 100, smartMeter1Id);
+        var policy2 = Policy.Create(new PolicyId(Guid.NewGuid()), "policy2", MeasurementResolution.Minute,
+            LocationResolution.Continent, 2000, smartMeter1Id);
+
+        SmartMeterId smartMeter2Id = new(Guid.Parse("1da14768-a0ce-432e-93b8-1b31e732c4af"));
+        SmartMeter smartMeter2 = SmartMeter.Create(smartMeter2Id, "Smart Meter 2", []);
+        var policy3 = Policy.Create(new PolicyId(Guid.NewGuid()), "policy3", MeasurementResolution.Week,
+            LocationResolution.StreetName, 200, smartMeter2Id);
+
+        await Policies.AddAsync(policy);
+        await Policies.AddAsync(policy2);
+        await Policies.AddAsync(policy3);
+        await SmartMeters.AddAsync(smartMeter1);
+        await SmartMeters.AddAsync(smartMeter2);
+
+        await InsertMeasurements(smartMeter1Id);
+        await InsertMeasurements(smartMeter2Id);
+
+        await SaveChangesAsync();
+    }
+
+    public async Task SeedTestDataForMaxMustermann()
+    {
+        SmartMeterId smartMeter1Id = new(Guid.Parse("96ae137c-a687-4423-b7ff-4cb0b238bfc7"));
+        Metadata metadata = Metadata.Create(new MetadataId(Guid.NewGuid()), DateTime.UtcNow,
+            new Location("Hochschulstraße 1", "Dornbirn", "Vorarlberg", "Österreich", Continent.Europe),
+            6, smartMeter1Id);
+        SmartMeter smartMeter1 = SmartMeter.Create(smartMeter1Id, "Smart Meter 1", [metadata]);
+        var policy = Policy.Create(new PolicyId(Guid.NewGuid()), "policy1", MeasurementResolution.Week,
+            LocationResolution.None, 500, smartMeter1Id);
+        var policy2 = Policy.Create(new PolicyId(Guid.NewGuid()), "policy2", MeasurementResolution.Raw,
+            LocationResolution.Continent, 5000, smartMeter1Id);
+
+        SmartMeterId smartMeter2Id = new(Guid.Parse("90b05cce-119f-40c4-9b28-e1d3088a109c"));
+        SmartMeter smartMeter2 = SmartMeter.Create(smartMeter2Id, "Smart Meter 2", []);
+        var policy3 = Policy.Create(new PolicyId(Guid.NewGuid()), "policy3", MeasurementResolution.Minute,
+            LocationResolution.StreetName, 4000, smartMeter2Id);
+
+        await Policies.AddAsync(policy);
+        await Policies.AddAsync(policy2);
+        await Policies.AddAsync(policy3);
+        await SmartMeters.AddAsync(smartMeter1);
+        await SmartMeters.AddAsync(smartMeter2);
+
+        await InsertMeasurements(smartMeter1Id);
+        await InsertMeasurements(smartMeter2Id);
+
+        await SaveChangesAsync();
+    }
+
+    private async Task InsertMeasurements(SmartMeterId smartMeterId)
+    {
+        const int batchSize = 50;
+
         await Database.OpenConnectionAsync();
-        var sql = @"
+        const string sqlTemplate = @"
             INSERT INTO domain.""Measurement""(""positiveActivePower"", ""positiveActiveEnergyTotal"", ""negativeActivePower"", ""negativeActiveEnergyTotal"", ""reactiveEnergyQuadrant1Total"", ""reactiveEnergyQuadrant3Total"", ""totalPower"", ""currentPhase1"", ""voltagePhase1"", ""currentPhase2"", ""voltagePhase2"", ""currentPhase3"", ""voltagePhase3"", ""uptime"", ""timestamp"", ""smartMeterId"") 
-            VALUES (@positiveActivePower, @positiveActiveEnergyTotal, @negativeActivePower, @negativeActiveEnergyTotal, @reactiveEnergyQuadrant1Total, @reactiveEnergyQuadrant3Total, @totalPower, @currentPhase1, @voltagePhase1, @currentPhase2, @voltagePhase2, @currentPhase3, @voltagePhase3, @uptime, @timestamp, @smartMeterId);
+            VALUES ({0});
         ";
+
+        var random = new Random();
+        var endDate = DateTime.UtcNow;
+        var startDate = endDate.AddDays(-2);
+        var interval = TimeSpan.FromSeconds(5);
+        var insertStatements = new List<string>();
+
+        for (var timestamp = startDate; timestamp <= endDate; timestamp += interval)
+        {
+            var values = $@"
+                {random.Next(100, 200)}, 
+                {random.Next(1000000, 2000000)}, 
+                {random.Next(0, 10)}, 
+                {random.Next(0, 10)}, 
+                {random.Next(1000, 5000)}, 
+                {random.Next(500000, 1000000)}, 
+                {random.Next(100, 200)}, 
+                {(random.NextDouble() * 10).ToString(CultureInfo.InvariantCulture)}, 
+                {(random.NextDouble() * 100 + 200).ToString(CultureInfo.InvariantCulture)}, 
+                {(random.NextDouble() * 10).ToString(CultureInfo.InvariantCulture)}, 
+                {(random.NextDouble() * 100 + 200).ToString(CultureInfo.InvariantCulture)}, 
+                {(random.NextDouble() * 10).ToString(CultureInfo.InvariantCulture)}, 
+                {(random.NextDouble() * 100 + 200).ToString(CultureInfo.InvariantCulture)}, 
+                '{timestamp.Subtract(startDate):dd\.hh\:mm\:ss}', 
+                '{timestamp:O}', 
+                '{smartMeterId.Id}'
+            ";
+
+            insertStatements.Add(string.Format(sqlTemplate, values));
+        }
+
         await using var insertCommand = Database.GetDbConnection().CreateCommand();
-        insertCommand.CommandText = sql;
+        int i;
+        for (i = 0; i < insertStatements.Count; i += 100)
+        {
+            var batch = insertStatements.Skip(i).Take(batchSize);
+            insertCommand.CommandText = string.Join(";", batch);
+            await insertCommand.ExecuteNonQueryAsync();
+        }
 
-        insertCommand.Parameters.Add(new NpgsqlParameter("@positiveActivePower", 160));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@positiveActiveEnergyTotal", 1137778));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@negativeActivePower", 1));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@negativeActiveEnergyTotal", 1));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@reactiveEnergyQuadrant1Total", 3837));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@reactiveEnergyQuadrant3Total", 717727));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@totalPower", 160));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@currentPhase1", 1.03));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@voltagePhase1", 229.80));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@currentPhase2", 0.42));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@voltagePhase2", 229.00));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@currentPhase3", 0.17));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@voltagePhase3", 229.60));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@uptime", "0000:01:49:41"));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@timestamp", DateTime.UtcNow));
-        insertCommand.Parameters.Add(new NpgsqlParameter("@smartMeterId", smartMeter1Id.Id));
+        // Execute the missing statements
+        var missingStatements = insertStatements.Skip(i).ToList();
+        if (missingStatements.Count > 0)
+        {
+            insertCommand.CommandText = string.Join(";", missingStatements);
+            await insertCommand.ExecuteNonQueryAsync();
+        }
 
-        await insertCommand.ExecuteNonQueryAsync();
         await Database.CloseConnectionAsync();
     }
 }


### PR DESCRIPTION
This pull request includes multiple changes to the `SMAIAXBackend` project to enhance database configuration, seed test data for multiple users, and log application startup time. The most important changes include updating the database seeding process for multiple test users, adding startup time logging, and code simplification.

### Enhancements to database seeding:
* [`src/SMAIAXBackend.API/Program.cs`](diffhunk://#diff-7343d072c9ab7637b63808399a1c7adcef8024cad09b331e4a93371110bef007L82-R113): Added seeding logic for multiple test users (John Doe, Jane Doe, Max Mustermann) and their respective databases and roles.
* [`src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs`](diffhunk://#diff-8dc02083b87e20558ba37c0eefb4871fa2fc96c819fee8f28e33cdbe2cf220b1L49-L71): Updated `SeedTestData` method to seed data for multiple test users and their respective tenants.
* [`src/SMAIAXBackend.Infrastructure/DbContexts/TenantDbContext.cs`](diffhunk://#diff-d1665246a52d7b06db53a6cf625cfd07e40aad3aef1744bfd88c455de0fb6a25L34-R180): Added methods to seed test data for each test user, including smart meters and policies.

### Logging improvements:
* [`src/SMAIAXBackend.API/Program.cs`](diffhunk://#diff-7343d072c9ab7637b63808399a1c7adcef8024cad09b331e4a93371110bef007R128-R129): Added logging for application startup time to measure the duration of the startup process.

### Code simplification:
* [`src/SMAIAXBackend.API/appsettings.Development.json`](diffhunk://#diff-4674f95d6357e545f1032f140ab4f1e26cf5248e75704b6034cd34f55a002283L16-L21): Removed hard-coded test user configuration to streamline the configuration file.
* [`src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs`](diffhunk://#diff-8dc02083b87e20558ba37c0eefb4871fa2fc96c819fee8f28e33cdbe2cf220b1L13-R13): Removed unused `IConfiguration` parameter from the constructor.