### PR TITLE
Filter already bought policies

### DIFF
--- a/src/SMAIAXBackend.Application/Services/Implementations/ContractListService.cs
+++ b/src/SMAIAXBackend.Application/Services/Implementations/ContractListService.cs
@@ -23,7 +23,7 @@ public class ContractListService(
 
         foreach (var contract in contracts)
         {
-            var vendorTenant = await tenantRepository.GetByIdAsync(new TenantId(contract.VendorId.Id));
+            var vendorTenant = await tenantRepository.GetByIdAsync(contract.VendorId);
 
             if (vendorTenant == null)
             {

--- a/tests/SMAIAXBackend.Application.UnitTests/PolicyListServiceTests.cs
+++ b/tests/SMAIAXBackend.Application.UnitTests/PolicyListServiceTests.cs
@@ -24,6 +24,7 @@ public class PolicyListServiceTests
     private Mock<ISmartMeterRepository> _smartMeterRepositoryMock;
     private Mock<IMeasurementListService> _measurementListServiceMock;
     private Mock<IMeasurementRepository> _measurementRepositoryMock;
+    private Mock<IContractRepository> _contractRepositoryMock;
 
     [OneTimeSetUp]
     public void OneTimeSetUp()
@@ -34,10 +35,10 @@ public class PolicyListServiceTests
         _tenantRepositoryMock = new Mock<ITenantRepository>();
         _measurementListServiceMock = new Mock<IMeasurementListService>();
         _measurementRepositoryMock = new Mock<IMeasurementRepository>();
+        _contractRepositoryMock = new Mock<IContractRepository>();
         _policyListService = new PolicyListService(_tenantRepositoryMock.Object, _smartMeterRepositoryMock.Object,
             _measurementRepositoryMock.Object, _policyRepositoryMock.Object, _measurementListServiceMock.Object,
-            _tenantContextServiceMock.Object,
-            Mock.Of<ILogger<PolicyListService>>());
+            _tenantContextServiceMock.Object, _contractRepositoryMock.Object, Mock.Of<ILogger<PolicyListService>>());
     }
 
     [Test]
@@ -152,6 +153,7 @@ public class PolicyListServiceTests
         _tenantRepositoryMock.Setup(repo => repo.GetAllAsync()).ReturnsAsync(tenants);
         _policyRepositoryMock.Setup(repo => repo.GetPoliciesByTenantAsync(tenants[0])).ReturnsAsync(policiesExpected);
         _policyRepositoryMock.Setup(repo => repo.GetPoliciesByTenantAsync(tenants[1])).ReturnsAsync([]);
+        _contractRepositoryMock.Setup(repo => repo.GetContractsForTenantAsync(currentTenant.Id)).ReturnsAsync([]);
 
         // When
         var policiesActual = await _policyListService.GetFilteredPoliciesAsync(maxPrice, measurementResolution, null);


### PR DESCRIPTION
This pull request includes changes to improve the functionality of the `PolicyListService` and its associated tests. The most important changes involve adding a new dependency to the service, updating methods to filter policies based on contracts, and enhancing the unit tests to cover the new functionality.

### Enhancements to `PolicyListService`:

* Added `IContractRepository` as a dependency to `PolicyListService` to allow fetching contracts.
* Updated `GetFilteredPoliciesAsync` method to filter out policies that are already associated with existing contracts.
* Fixed a logging message in `GetMeasurementsByPolicyIdAsync` to use the correct format for the policy ID.

### Updates to `ContractListService`:

* Simplified the retrieval of vendor tenant by removing the unnecessary wrapping of `VendorId`.

### Enhancements to unit tests:

* Added a mock for `IContractRepository` in `PolicyListServiceTests`.
* Updated the `OneTimeSetUp` method to include the new `IContractRepository` dependency.
* Enhanced the test `GivenExistingPolicies_WhenGetFilteredPolicies_ThenReturnFilter` to set up the mock for `GetContractsForTenantAsync` and verify the filtering logic.