### PR TITLE
Add fixed tenant id when seeding data

### DIFF
--- a/src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs
+++ b/src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs
@@ -65,7 +65,8 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         var johnDoePasswordHash = hasher.HashPassword(johnDoeTestUser, johnDoePassword!);
         johnDoeTestUser.PasswordHash = johnDoePasswordHash;
 
-        var johnDoeTenant = Tenant.Create(new TenantId(Guid.NewGuid()), "tenant_1_role", johnDoeTenantDatabase!);
+        var johnDoeTenant = Tenant.Create(new TenantId(Guid.Parse("4846f8c1-d322-48a3-9d5a-b86219c9e14a")),
+            "tenant_1_role", johnDoeTenantDatabase!);
         var johnDoeDomainUser = User.Create(johnDoeUserId, new Name("John", "Doe"), johnDoeUserName, johnDoeEmail,
             johnDoeTenant.Id);
 
@@ -86,7 +87,8 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         var janeDoePasswordHash = hasher.HashPassword(janeDoeTestUser, janeDoePassword!);
         janeDoeTestUser.PasswordHash = janeDoePasswordHash;
 
-        var janeDoeTenant = Tenant.Create(new TenantId(Guid.NewGuid()), "tenant_2_role", janeDoeTenantDatabase!);
+        var janeDoeTenant = Tenant.Create(new TenantId(Guid.Parse("24f037f5-bcd1-4eaa-9054-d87ca14a7765")),
+            "tenant_2_role", janeDoeTenantDatabase!);
         var janeDoeDomainUser = User.Create(janeDoeUserId, new Name("Jane", "Doe"), janeDoeUserName, janeDoeEmail,
             janeDoeTenant.Id);
 
@@ -108,7 +110,8 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         maxMustermannTestUser.PasswordHash = maxMustermannPasswordHash;
 
         var maxMustermannTenant =
-            Tenant.Create(new TenantId(Guid.NewGuid()), "tenant_3_role", maxMustermannTenantDatabase!);
+            Tenant.Create(new TenantId(Guid.Parse("8f864f2c-5a92-4a1a-bf59-a65f2579250d")), "tenant_3_role",
+                maxMustermannTenantDatabase!);
         var maxMustermannDomainUser = User.Create(maxMustermannUserId, new Name("Max", "Mustermann"),
             maxMustermannUserName, maxMustermannEmail, maxMustermannTenant.Id);
 


### PR DESCRIPTION
This pull request includes changes to the `SeedTestData` method in the `ApplicationDbContext` class to use specific GUIDs for tenant creation instead of generating new GUIDs each time. This ensures consistency and predictability in the test data.

Changes to `SeedTestData` method:

* [`src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs`](diffhunk://#diff-8dc02083b87e20558ba37c0eefb4871fa2fc96c819fee8f28e33cdbe2cf220b1L68-R69): Modified the creation of `johnDoeTenant` to use a specific GUID `4846f8c1-d322-48a3-9d5a-b86219c9e14a`.
* [`src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs`](diffhunk://#diff-8dc02083b87e20558ba37c0eefb4871fa2fc96c819fee8f28e33cdbe2cf220b1L89-R91): Modified the creation of `janeDoeTenant` to use a specific GUID `24f037f5-bcd1-4eaa-9054-d87ca14a7765`.
* [`src/SMAIAXBackend.Infrastructure/DbContexts/ApplicationDbContext.cs`](diffhunk://#diff-8dc02083b87e20558ba37c0eefb4871fa2fc96c819fee8f28e33cdbe2cf220b1L111-R114): Modified the creation of `maxMustermannTenant` to use a specific GUID `8f864f2c-5a92-4a1a-bf59-a65f2579250d`.